### PR TITLE
Add integration with Eclipse JDT Language Server

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Auto detect text files and perform LF normalization
-* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+grammars/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 grammars/
+target/
+Cargo.lock
+extension.wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "java"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This extension adds support for the [Java](https://github.com/zed-extensions/jav
 
 ## Configuration
 
-You can optionally configure the Java home that JDTLS (the language server) uses like so:
+You can optionally configure the Java home that JDTLS (the language server) uses
+in your Zed settings like so:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Zed Java
 
 This extension adds support for the [Java](https://github.com/zed-extensions/java) language.
+
+## Configuration
+
+You can optionally configure the Java home that JDTLS (the language server) uses like so:
+
+```json
+{
+  "lsp": {
+    "jdtls": {
+      "settings": {
+        "java_home": "/path/to/jdk"
+      }
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Zed Java
 
-This extension adds support for the [Java](https://github.com/samuser107/extensions-zed) language.
+This extension adds support for the [Java](https://github.com/zed-extensions/java) language.

--- a/extension.json
+++ b/extension.json
@@ -1,9 +1,0 @@
-{
-  "name": "Java",
-  "version": "0.0.4",
-  "authors": [
-    "Samuser107 L.Longheval <samuser107@gmail.com>"
-  ],
-  "description": "Provides Java syntax highlighting in Zed (and language support is coming later)",
-  "repository": "https://github.com/samuser107/zed-java-extension"
-}

--- a/extension.toml
+++ b/extension.toml
@@ -13,3 +13,7 @@ repository = "https://github.com/zed-extensions/java"
 [grammars.java]
 repository = "https://github.com/tree-sitter/tree-sitter-java"
 commit = "99b29f1ed957b3b424b6e21f57bd21a9732a622a"
+
+[language_servers.jdtls]
+name = "Eclipse JDT Language Server"
+language = "Java"

--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,15 @@
+id = "java"
+name = "Java"
+version = "1.0.0"
+schema_version = 1
+authors = [
+    "Samuser107 L.Longheval <samuser107@gmail.com>",
+    "Valentine Briese <valentinegb@icloud.com>",
+    "Yury Abykhodau <abehodau@gmail.com>",
+]
+description = "Java support."
+repository = "https://github.com/zed-extensions/java"
+
+[grammars.java]
+repository = "https://github.com/tree-sitter/tree-sitter-java"
+commit = "99b29f1ed957b3b424b6e21f57bd21a9732a622a"

--- a/grammars/java.toml
+++ b/grammars/java.toml
@@ -1,2 +1,0 @@
-repository = "https://github.com/tree-sitter/tree-sitter-java"
-commit = "99b29f1ed957b3b424b6e21f57bd21a9732a622a"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,24 @@ impl zed::Extension for Java {
                             CodeLabelSpan::literal(" : ", None),
                             CodeLabelSpan::code_range(0..field_type.len()),
                         ],
-                        filter_range: (0..completion.label.len()).into(),
                         code,
+                        filter_range: (0..completion.label.len()).into(),
+                    });
+                }
+                CompletionKind::Method => {
+                    let (left, return_type) = completion.detail.as_ref()?.split_once(" : ")?;
+                    let parameters = &left[left.find('(')?..];
+                    let name_and_parameters = format!("{}{parameters}", completion.label);
+                    let code = format!("{return_type} {name_and_parameters} {{}}");
+
+                    return Some(CodeLabel {
+                        spans: vec![
+                            CodeLabelSpan::code_range(return_type.len() + 1..code.len() - 3),
+                            CodeLabelSpan::literal(" : ", None),
+                            CodeLabelSpan::code_range(0..return_type.len()),
+                        ],
+                        code,
+                        filter_range: (0..completion.label.len()).into(),
                     });
                 }
                 _ => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,21 +81,46 @@ impl zed::Extension for Java {
                         filter_range: (0..completion.label.len()).into(),
                     });
                 }
-                CompletionKind::Class => {
-                    let class = "class ";
+                CompletionKind::Class | CompletionKind::Interface | CompletionKind::Enum => {
+                    let keyword = match kind {
+                        CompletionKind::Class => "class ",
+                        CompletionKind::Interface => "interface ",
+                        CompletionKind::Enum => "enum ",
+                        _ => return None,
+                    };
                     let braces = " {}";
-                    let code = format!("{class}{}{braces}", completion.label);
+                    let code = format!("{keyword}{}{braces}", completion.label);
                     let detail = completion.detail?;
                     let namespace = &detail[..detail.len() - completion.label.len() - 1];
 
                     return Some(CodeLabel {
                         spans: vec![
-                            CodeLabelSpan::code_range(class.len()..code.len() - braces.len()),
+                            CodeLabelSpan::code_range(keyword.len()..code.len() - braces.len()),
                             CodeLabelSpan::literal(format!(" ({namespace})"), None),
                         ],
                         code,
                         filter_range: (0..completion.label.len()).into(),
                     });
+                }
+                CompletionKind::Snippet => {
+                    return Some(CodeLabel {
+                        code: String::new(),
+                        spans: vec![CodeLabelSpan::literal(
+                            format!("{} - {}", completion.label, completion.detail?),
+                            None,
+                        )],
+                        filter_range: (0..completion.label.len()).into(),
+                    });
+                }
+                CompletionKind::Keyword => {
+                    return Some(CodeLabel {
+                        spans: vec![CodeLabelSpan::code_range(0..completion.label.len())],
+                        filter_range: (0..completion.label.len()).into(),
+                        code: completion.label,
+                    });
+                }
+                CompletionKind::Module => {
+                    return None;
                 }
                 _ => (),
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl zed::Extension for Java {
                         filter_range: (0..completion.label.len()).into(),
                     });
                 }
-                CompletionKind::Keyword => {
+                CompletionKind::Keyword | CompletionKind::Variable => {
                     return Some(CodeLabel {
                         spans: vec![CodeLabelSpan::code_range(0..completion.label.len())],
                         filter_range: (0..completion.label.len()).into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,15 +12,31 @@ impl zed::Extension for Java {
 
     fn language_server_command(
         &mut self,
-        _language_server_id: &zed::LanguageServerId,
+        language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> zed::Result<zed::Command> {
+        let java_home =
+            zed::settings::LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
+                .settings
+                .and_then(|settings| {
+                    settings.get("java_home").and_then(|java_home_value| {
+                        java_home_value
+                            .as_str()
+                            .and_then(|java_home_str| Some(java_home_str.to_string()))
+                    })
+                });
+        let mut env = Vec::new();
+
+        if let Some(java_home) = java_home {
+            env.push(("JAVA_HOME".to_string(), java_home));
+        }
+
         Ok(zed::Command {
             command: worktree
                 .which("jdtls")
                 .ok_or("could not find JDTLS in PATH")?,
-            args: vec![],
-            env: vec![],
+            args: Vec::new(),
+            env,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,9 @@ impl zed::Extension for Java {
         _language_server_id: &zed::LanguageServerId,
         completion: zed::lsp::Completion,
     ) -> Option<zed::CodeLabel> {
+        // uncomment when debugging completions
+        // println!("Java completion: {completion:#?}");
+
         if let Some(kind) = completion.kind {
             match kind {
                 CompletionKind::Field | CompletionKind::Constant => {
@@ -145,7 +148,6 @@ impl zed::Extension for Java {
                         code: completion.label,
                     });
                 }
-                CompletionKind::Module => return None,
                 CompletionKind::Constructor => {
                     let detail = completion.detail?;
                     let parameters = &detail[detail.find('(')?..];
@@ -161,8 +163,6 @@ impl zed::Extension for Java {
                 _ => (),
             }
         }
-
-        println!("unhandled Java completion: {completion:#?}"); // warn
 
         None
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,28 @@
+use zed_extension_api as zed;
+
+struct Java;
+
+impl zed::Extension for Java {
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> zed::Result<zed::Command> {
+        Ok(zed::Command {
+            command: worktree
+                .which("jdtls")
+                .ok_or("could not find JDTLS in PATH")?,
+            args: vec![],
+            env: vec![],
+        })
+    }
+}
+
+zed::register_extension!(Java);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,18 @@ impl zed::Extension for Java {
                 CompletionKind::Module => {
                     return None;
                 }
+                CompletionKind::Constructor => {
+                    let detail = completion.detail?;
+                    let parameters = &detail[detail.find('(')?..];
+                    let braces = " {}";
+                    let code = format!("{}{parameters}{braces}", completion.label);
+
+                    return Some(CodeLabel {
+                        spans: vec![CodeLabelSpan::code_range(0..code.len() - braces.len())],
+                        code,
+                        filter_range: (0..completion.label.len()).into(),
+                    });
+                }
                 _ => (),
             }
         }


### PR DESCRIPTION
Uses JDTLS for LSP integration if it is installed and allows users to configure the Java home.

Handles the following `CompletionKind`s:

- `Field`
- `Method`
- `Class`
- `Interface`
- `Enum`
- `Snippet`
- `Keyword`
- `Module`
- `Constructor`
- `Variable`
- `Constant`

Please let me know if you find any more that JDTLS gives! Also accepting suggestions from developers who use Java more than I do on how to label these completions.

Resolves #4.