### PR TITLE
Replace unsupported highlights captures

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/zed-extensions/java"
 
 [grammars.java]
 repository = "https://github.com/tree-sitter/tree-sitter-java"
-commit = "99b29f1ed957b3b424b6e21f57bd21a9732a622a"
+commit = "490d878cf33b0ad5ae7a7253ff30597a5bdc348e"
 
 [language_servers.jdtls]
 name = "Eclipse JDT Language Server"

--- a/languages/java/highlights.scm
+++ b/languages/java/highlights.scm
@@ -310,10 +310,4 @@
 ] @comment
 
 ((block_comment) @comment.doc
-  (#match? @comment.doc "^/[*][*][^*].*[*]/$"))
-
-((line_comment) @comment.doc
-  (#match? @comment.doc "^///[^/]"))
-
-((line_comment) @comment.doc
-  (#match? @comment.doc "^///$"))
+  (#match? @comment.doc "^\\/\\*\\*"))

--- a/languages/java/highlights.scm
+++ b/languages/java/highlights.scm
@@ -4,30 +4,30 @@
 
 ; Methods
 (method_declaration
-  name: (identifier) @function.method)
+  name: (identifier) @function)
 
 (method_invocation
-  name: (identifier) @function.method.call)
+  name: (identifier) @function)
 
-(super) @function.builtin
+(super) @function
 
 ; Parameters
 (formal_parameter
-  name: (identifier) @variable.parameter)
+  name: (identifier) @variable)
 
 (catch_formal_parameter
-  name: (identifier) @variable.parameter)
+  name: (identifier) @variable)
 
 (spread_parameter
   (variable_declarator
-    name: (identifier) @variable.parameter)) ; int... foo
+    name: (identifier) @variable)) ; int... foo
 
 ; Lambda parameter
 (inferred_parameters
-  (identifier) @variable.parameter) ; (x,y) -> ...
+  (identifier) @variable) ; (x,y) -> ...
 
 (lambda_expression
-  parameters: (identifier) @variable.parameter) ; x -> ...
+  parameters: (identifier) @variable) ; x -> ...
 
 ; Operators
 [
@@ -82,54 +82,57 @@
   name: (identifier) @type)
 
 (enum_declaration
-  name: (identifier) @type)
+  name: (identifier) @enum)
 
 (constructor_declaration
-  name: (identifier) @type)
+  name: (identifier) @constructor)
 
 (type_identifier) @type
 
-((type_identifier) @type.builtin
-  (#eq? @type.builtin "var"))
+((type_identifier) @type
+  (#eq? @type "var"))
+
+(object_creation_expression
+  type: (type_identifier) @constructor)
 
 ((method_invocation
   object: (identifier) @type)
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ((method_reference
   .
   (identifier) @type)
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ((field_access
   object: (identifier) @type)
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 (scoped_identifier
   (identifier) @type
-  (#lua-match? @type "^[A-Z]"))
+  (#match? @type "^[A-Z]"))
 
 ; Fields
 (field_declaration
   declarator:
     (variable_declarator
-      name: (identifier) @variable.member))
+      name: (identifier) @property))
 
 (field_access
-  field: (identifier) @variable.member)
+  field: (identifier) @property)
 
 [
   (boolean_type)
   (integral_type)
   (floating_point_type)
   (void_type)
-] @type.builtin
+] @type
 
 ; Variables
 ((identifier) @constant
-  (#lua-match? @constant "^[A-Z_][A-Z%d_]+$"))
+  (#match? @constant "^[A-Z_][A-Z%d_]+$"))
 
-(this) @variable.builtin
+(this) @variable
 
 ; Annotations
 (annotation
@@ -145,26 +148,23 @@
 
 (escape_sequence) @string.escape
 
-(character_literal) @character
+(character_literal) @string
 
 [
   (hex_integer_literal)
   (decimal_integer_literal)
   (octal_integer_literal)
   (binary_integer_literal)
-] @number
-
-[
   (decimal_floating_point_literal)
   (hex_floating_point_literal)
-] @number.float
+] @number
 
 [
   (true)
   (false)
 ] @boolean
 
-(null_literal) @constant.builtin
+(null_literal) @type
 
 ; Keywords
 [
@@ -183,9 +183,6 @@
   "with"
 ] @keyword
 
-(synchronized_statement
-  "synchronized" @keyword)
-
 [
   "abstract"
   "final"
@@ -198,23 +195,21 @@
   "sealed"
   "static"
   "strictfp"
+  "synchronized"
   "transitive"
-] @type.qualifier
-
-(modifiers
-  "synchronized" @type.qualifier)
+] @keyword
 
 [
   "transient"
   "volatile"
-] @keyword.storage
+] @keyword
 
 [
   "return"
   "yield"
-] @keyword.return
+] @keyword
 
-"new" @keyword.operator
+"new" @operator
 
 ; Conditionals
 [
@@ -222,13 +217,13 @@
   "else"
   "switch"
   "case"
-] @keyword.conditional
+] @keyword
 
 (ternary_expression
   [
     "?"
     ":"
-  ] @keyword.conditional.ternary)
+  ] @operator)
 
 ; Loops
 [
@@ -237,7 +232,7 @@
   "do"
   "continue"
   "break"
-] @keyword.repeat
+] @keyword
 
 ; Includes
 [
@@ -249,7 +244,7 @@
   "provides"
   "requires"
   "uses"
-] @keyword.import
+] @keyword
 
 ; Punctuation
 [
@@ -290,7 +285,7 @@
   [
     "\\{"
     "}"
-  ] @punctuation.special)
+  ] @string.special.symbol)
 
 ; Exceptions
 [
@@ -299,7 +294,7 @@
   "finally"
   "try"
   "catch"
-] @keyword.exception
+] @keyword
 
 ; Labels
 (labeled_statement
@@ -309,13 +304,13 @@
 [
   (line_comment)
   (block_comment)
-] @comment @spell
+] @comment
 
-((block_comment) @comment.documentation
-  (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
+((block_comment) @comment.doc
+  (#match? @comment.doc "^/[*][*][^*].*[*]/$"))
 
-((line_comment) @comment.documentation
-  (#lua-match? @comment.documentation "^///[^/]"))
+((line_comment) @comment.doc
+  (#match? @comment.doc "^///[^/]"))
 
-((line_comment) @comment.documentation
-  (#lua-match? @comment.documentation "^///$"))
+((line_comment) @comment.doc
+  (#match? @comment.doc "^///$"))

--- a/languages/java/highlights.scm
+++ b/languages/java/highlights.scm
@@ -84,6 +84,9 @@
 (enum_declaration
   name: (identifier) @enum)
 
+(enum_constant
+  name: (identifier) @constant)
+
 (constructor_declaration
   name: (identifier) @constructor)
 
@@ -130,7 +133,7 @@
 
 ; Variables
 ((identifier) @constant
-  (#match? @constant "^[A-Z_][A-Z%d_]+$"))
+  (#match? @constant "^[A-Z_$][A-Z\\d_$]*$"))
 
 (this) @variable
 


### PR DESCRIPTION
There are a number of instances in the `highlights.scm` where captures which aren't supported in Zed are used. This PR replaces those captures with supported captures.

Since this PR changes the syntax highlighting in a way that may appear arbitrary to some, I'd like to make sure most users are happy with the changes. Please let me know if you are or you aren't!

| Before                                                                                                                                            | After                                                                                                                                             |
|---------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="403" alt="Screenshot 2024-10-11 at 4 34 34 PM" src="https://github.com/user-attachments/assets/ab34129c-356f-4edb-9364-3eda8e195c90"> | <img width="403" alt="Screenshot 2024-10-11 at 4 33 59 PM" src="https://github.com/user-attachments/assets/50fb15b3-083b-438f-8aaf-52db38f88568"> |
