### PR TITLE
Download jdtls to extension work directory if not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,19 @@
 
 This extension adds support for the Java language.
 
-> [!NOTE]
-> The extension does not currently install [JDTLS] (the language server the extension uses) for you.
-> If you wish to enable LSP functionality, please install [JDTLS] yourself.
-
 ## Configuration
 
 ### Settings
 
-You can optionally configure the class path that [JDTLS] (the language server) uses in your Zed
-settings like so:
+You can optionally configure the version of [JDTLS] (the language server) to
+download or the class path that [JDTLS] uses in your Zed settings like so:
 
 ```json
 {
   "lsp": {
     "jdtls": {
       "settings": {
+        "version": "1.40.0", // This is the default value
         "classpath": "/path/to/classes.jar:/path/to/more/classes/"
       }
     }
@@ -27,7 +24,8 @@ settings like so:
 
 ### Initialization Options
 
-There are also many more options you can pass directly to the language server, for example:
+There are also many more options you can pass directly to the language server,
+for example:
 
 ```json
 {
@@ -110,7 +108,8 @@ There are also many more options you can pass directly to the language server, f
 
 *Example taken from JDTLS's [initialization options wiki page].*
 
-You can see all the options JDTLS accepts [here][initialization options wiki page].
+You can see all the options JDTLS accepts [here][initialization options wiki
+page].
 
 [JDTLS]: https://github.com/eclipse-jdtls/eclipse.jdt.ls
 [initialization options wiki page]: https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@ impl Java {
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
 
-        // Use version specified in settings or latest version released on Github
-        let version = match LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
+        // Use version specified in settings or default version
+        let version = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
             .settings
             .and_then(|settings| {
                 settings.get("version").and_then(|version_value| {
@@ -52,23 +52,8 @@ impl Java {
                         .map(|version_str| version_str.trim().to_string())
                 })
             })
-            .or_else(|| {
-                // Probably we can get the latest version from Maven?
-                Some("1.40.0".to_string())
-            }) {
-            Some(version) => version,
-            None => {
-                zed::set_language_server_installation_status(
-                    language_server_id,
-                    &zed::LanguageServerInstallationStatus::Failed(
-                        "no version specified in settings and no latest release found".to_string(),
-                    ),
-                );
-                return Err(
-                    "no version specified in settings and no latest release found".to_string(),
-                );
-            }
-        };
+            // Probably we can get the latest version from Maven?
+            .unwrap_or("1.40.0".to_string());
 
         // Prebuilt milestone versions available at:
         // https://download.eclipse.org/jdtls/milestones/{version}


### PR DESCRIPTION
Hi!
This change downloads jdtls if it does not exist on $PATH.
I couldn't find any CLA nor guidelines for zed-extensions, so do please advise if there is any.