### PR TITLE
Add lombok as javaagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ download or the class path that [JDTLS] uses in your Zed settings.
 
 If [lombok] support is enabled via [JDTLS] initialization option
 (`initialization_options.settings.java.jdt.ls.lombokSupport.enabled`), this
-extension will add `lombok` as a javaagent to the JVM arguments for [JDTLS].
-You can also configure the version of `lombok` to use via setting the version
+extension will add [lombok] as a javaagent to the JVM arguments for [JDTLS].
+You can also configure the version of [lombok] to use via setting the version
 at `settings.lombok_version`.
 
 Below is a configuration example for this extension:

--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ download or the class path that [JDTLS] uses in your Zed settings like so:
   "lsp": {
     "jdtls": {
       "settings": {
-        "version": "1.40.0", // This is the default value
-        "classpath": "/path/to/classes.jar:/path/to/more/classes/"
+        "classpath": "/path/to/classes.jar:/path/to/more/classes/",
+        "jdtls": {
+          "version": "1.40.0", // This is the default value
+        },
+        "lombok": { // Only needed if `initialization_options.settings.java.jdt.ls.lombokSupport.enabled` is set to `true`
+          "version": "1.18.34", // Defaults to the latest version if not set
+        }
       }
     }
   }
@@ -65,6 +70,9 @@ for example:
                 "**/META-INF/maven/**",
                 "/**/test/**"
               ]
+            },
+            "lombokSupport": {
+              "enabled": false
             },
             "referencesCodeLens": {
               "enabled": false

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This extension adds support for the Java language.
 You can optionally configure the version of [JDTLS] (the language server) to
 download or the class path that [JDTLS] uses in your Zed settings.
 
-If [lombok] support is enabled via [JDTLS] initialization option
+If [Lombok] support is enabled via [JDTLS] initialization option
 (`initialization_options.settings.java.jdt.ls.lombokSupport.enabled`), this
-extension will add [lombok] as a javaagent to the JVM arguments for [JDTLS].
-You can also configure the version of [lombok] to use via setting the version
+extension will add [Lombok] as a javaagent to the JVM arguments for [JDTLS].
+You can also configure the version of [Lombok] to use via setting the version
 at `settings.lombok_version`.
 
 Below is a configuration example for this extension:
@@ -125,4 +125,4 @@ page].
 
 [JDTLS]: https://github.com/eclipse-jdtls/eclipse.jdt.ls
 [initialization options wiki page]: https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request
-[lombok]: https://projectlombok.org
+[Lombok]: https://projectlombok.org

--- a/README.md
+++ b/README.md
@@ -15,12 +15,8 @@ download or the class path that [JDTLS] uses in your Zed settings like so:
     "jdtls": {
       "settings": {
         "classpath": "/path/to/classes.jar:/path/to/more/classes/",
-        "jdtls": {
-          "version": "1.40.0", // This is the default value
-        },
-        "lombok": { // Only needed if `initialization_options.settings.java.jdt.ls.lombokSupport.enabled` is set to `true`
-          "version": "1.18.34", // Defaults to the latest version if not set
-        }
+        "jdtls_version": "1.40.0", // This is the default value
+        "lombok_version": "1.18.34" // Defaults to the latest version if not set
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -7,16 +7,24 @@ This extension adds support for the Java language.
 ### Settings
 
 You can optionally configure the version of [JDTLS] (the language server) to
-download or the class path that [JDTLS] uses in your Zed settings like so:
+download or the class path that [JDTLS] uses in your Zed settings.
 
-```json
+If [lombok] support is enabled via [JDTLS] initialization option
+(`initialization_options.settings.java.jdt.ls.lombokSupport.enabled`), this
+extension will add `lombok` as a javaagent to the JVM arguments for [JDTLS].
+You can also configure the version of `lombok` to use via setting the version
+at `settings.lombok_version`.
+
+Below is a configuration example for this extension:
+
+```jsonc
 {
   "lsp": {
     "jdtls": {
       "settings": {
         "classpath": "/path/to/classes.jar:/path/to/more/classes/",
         "jdtls_version": "1.40.0", // This is the default value
-        "lombok_version": "1.18.34" // Defaults to the latest version if not set
+        "lombok_version": "1.18.34" // Defaults to latest version if not set
       }
     }
   }
@@ -28,7 +36,7 @@ download or the class path that [JDTLS] uses in your Zed settings like so:
 There are also many more options you can pass directly to the language server,
 for example:
 
-```json
+```jsonc
 {
   "lsp": {
     "jdtls": {
@@ -68,7 +76,7 @@ for example:
               ]
             },
             "lombokSupport": {
-              "enabled": false
+              "enabled": false // Set this to true to enable lombok support
             },
             "referencesCodeLens": {
               "enabled": false
@@ -117,3 +125,4 @@ page].
 
 [JDTLS]: https://github.com/eclipse-jdtls/eclipse.jdt.ls
 [initialization options wiki page]: https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request
+[lombok]: https://projectlombok.org

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,6 @@ impl Java {
                 );
             })?;
         }
-
         self.cached_lombok_path = Some(lombok_path.to_string());
         Ok(lombok_path.to_string())
     }
@@ -342,7 +341,7 @@ impl zed::Extension for Java {
                         keyword.len()..code.len() - braces.len(),
                     )];
 
-                    if let Some(namespace); = namespace {
+                    if let Some(namespace) = namespace {
                         spans.push(CodeLabelSpan::literal(format!(" ({namespace})"), None));
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,14 +390,15 @@ impl zed::Extension for Java {
 }
 
 fn get_value<'a>(keys: Vec<&'a str>, value: &'a Value) -> Option<&'a Value> {
-    return keys.first().and_then(|key| {
+    keys.first().and_then(|key| {
         value.get(key).and_then(|key_value| {
             if keys.len() > 1 {
-                return get_value(keys[1..keys.len()].to_vec(), key_value);
+                get_value(keys[1..keys.len()].to_vec(), key_value)
+            } else {
+                Some(key_value)
             }
-            return Some(key_value);
         })
-    });
+    })
 }
 
 zed::register_extension!(Java);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ impl Java {
         let version = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
             .settings
             .and_then(|settings| {
-                get_value(vec!["jdtls", "version"], &settings).and_then(|version| {
+                settings.get("jdtls_version").and_then(|version| {
                     version
                         .as_str()
                         .map(|version_str| version_str.trim().to_string())
@@ -150,7 +150,8 @@ impl Java {
         let lombok_version = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
             .settings
             .and_then(|settings| {
-                get_value(vec!["lombok", "version"], &settings)
+                settings
+                    .get("lombok_version")
                     .and_then(|version| version.as_str())
                     .map(|version_str| version_str.to_string())
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ impl Java {
                 );
             })?;
         }
+
         self.cached_lombok_path = Some(lombok_path.to_string());
         Ok(lombok_path.to_string())
     }
@@ -237,7 +238,6 @@ impl zed::Extension for Java {
                 .and_then(|enabled| enabled.as_bool())
             })
             .unwrap_or(false);
-        println!("lombok_enabled: {:?}", lombok_enabled);
         if lombok_enabled {
             let lombok_jar_path = self.lombok_jar_path(language_server_id, worktree)?;
             let lombok_jar_full_path = std::env::current_dir()
@@ -342,7 +342,7 @@ impl zed::Extension for Java {
                         keyword.len()..code.len() - braces.len(),
                     )];
 
-                    if let Some(namespace) = namespace {
+                    if let Some(namespace); = namespace {
                         spans.push(CodeLabelSpan::literal(format!(" ({namespace})"), None));
                     }
 


### PR DESCRIPTION
Hi again!
This adds lombok as jvm argument when jdtls is launched, with version specified on settings, or the latest version if unspecified.
This is my settings for reference.
```json
"jdtls": {
  "settings": {
    "lombok": {
      "enabled": true,
      "version": "1.18.34"
    },
    "version": "1.40.0"
  },
  "initialization_options": {
    "settings": {
      "java": {
        "configuration": {
          "runtimes": [
            {
              "name": "JavaSE-21",
              "path": "/home/me/.sdkman/candidates/java/21-oracle"
            }
          ]
        },
        "format": {
          "settings": {
            "profile": "GoogleStyle"
          }
        },
        "import": {
          "gradle": {
            "enabled": true,
            "java": {
              "home": "/home/me/.sdkman/candidates/java/21-oracle"
            },
            "wrapper": {
              "enabled": true
            }
          }
        },
        "jdt": {
          "ls": {
            "java": {
              "home": "/home/me/.sdkman/candidates/java/21-oracle"
            },
            "lombokSupport": {
              "enabled": true
            }
          }
        },
        "maven": {
          "downloadSources": true
        }
      }
    }
  }
}
```