### PR TITLE
Auto download latest version of JDTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This extension adds support for the Java language.
 
 ### Settings
 
-You can optionally configure the version of [JDTLS] (the language server) to
-download or the class path that [JDTLS] uses in your Zed settings.
+You can optionally configure the class path that [JDTLS] uses in your Zed
+settings.
 
 If [Lombok] support is enabled via [JDTLS] initialization option
 (`initialization_options.settings.java.jdt.ls.lombokSupport.enabled`), this
@@ -23,7 +23,6 @@ Below is a configuration example for this extension:
     "jdtls": {
       "settings": {
         "classpath": "/path/to/classes.jar:/path/to/more/classes/",
-        "jdtls_version": "1.40.0", // This is the default value
         "lombok_version": "1.18.34" // Defaults to latest version if not set
       }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,13 +107,17 @@ impl Java {
 
             // ...and delete other versions
 
-            let entries = fs::read_dir(".").map_err(|err| err.to_string())?;
+            let entries = fs::read_dir(".")
+                .map_err(|err| format!("failed to list working directory: {err}"))?;
 
             for entry in entries {
-                let entry = entry.map_err(|err| err.to_string())?;
+                let entry =
+                    entry.map_err(|err| format!("failed to load directory entry: {err}"))?;
 
                 if entry.file_name().to_str() != Some(build_path) {
-                    fs::remove_dir_all(entry.path()).ok();
+                    if let Err(err) = fs::remove_dir_all(entry.path()) {
+                        println!("failed to remove directory entry: {err}");
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,15 @@
+use std::fs;
+
 use zed_extension_api::{
-    self as zed, current_platform, download_file, lsp::Completion, lsp::CompletionKind,
-    make_file_executable, register_extension, set_language_server_installation_status,
-    settings::LspSettings, CodeLabel, CodeLabelSpan, DownloadedFileType, Extension,
-    LanguageServerId, LanguageServerInstallationStatus, Os, Worktree,
+    self as zed, current_platform, download_file,
+    http_client::{fetch, HttpMethod, HttpRequest},
+    lsp::{Completion, CompletionKind},
+    make_file_executable, register_extension,
+    serde_json::{self, Value},
+    set_language_server_installation_status,
+    settings::LspSettings,
+    CodeLabel, CodeLabelSpan, DownloadedFileType, Extension, LanguageServerId,
+    LanguageServerInstallationStatus, Os, Worktree,
 };
 
 struct Java {
@@ -16,120 +23,100 @@ impl Java {
         language_server_id: &LanguageServerId,
         worktree: &Worktree,
     ) -> zed::Result<String> {
-        // Quickly return if the binary path is already cached
-        // Expect binary path to be validated when setting the cache so no checking is done here
+        // Use cached path if exists
+
         if let Some(path) = &self.cached_binary_path {
-            return Ok(path.clone());
-        }
-
-        // Determine the binary name based on the current platform
-        let (platform, _) = current_platform();
-        let binary_name = match platform {
-            Os::Windows => "jdtls.bat",
-            _ => "jdtls",
-        }
-        .to_string();
-
-        // Use binary available on PATH if it exists
-        if let Some(path) = worktree.which(&binary_name) {
-            // Probably we want to check if the binary is executable too here
-            if std::fs::metadata(&path).map_or(false, |stat| stat.is_file()) {
-                self.cached_binary_path = Some(path.clone());
+            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
                 return Ok(path.clone());
             }
         }
 
-        // Attempt to install locally
+        // Use $PATH if binary is in it
+
+        let (platform, _) = current_platform();
+        let binary_name = match platform {
+            Os::Windows => "jdtls.bat",
+            _ => "jdtls",
+        };
+
+        if let Some(path_binary) = worktree.which(binary_name) {
+            return Ok(path_binary);
+        }
+
+        // Check for latest version
 
         set_language_server_installation_status(
             language_server_id,
             &LanguageServerInstallationStatus::CheckingForUpdate,
         );
 
-        // Use version specified in settings or default version
-        let version = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
-            .settings
-            .and_then(|settings| {
-                settings.get("jdtls_version").and_then(|version| {
-                    version
-                        .as_str()
-                        .map(|version_str| version_str.trim().to_string())
-                })
-            })
-            // Probably we can get the latest version from Maven?
-            .unwrap_or("1.40.0".to_string());
+        let tags_response_body = serde_json::from_slice::<Value>(
+            &fetch(
+                &HttpRequest::builder()
+                    .method(HttpMethod::Get)
+                    .url("https://api.github.com/repos/eclipse-jdtls/eclipse.jdt.ls/tags")
+                    .build()?,
+            )?
+            .body,
+        )
+        .map_err(|err| err.to_string())?;
+        let latest_version = &tags_response_body
+            .as_array()
+            .ok_or("expected array")?
+            .first()
+            .ok_or("expected at least one tag")?
+            .get("name")
+            .ok_or("expected tag to have name")?
+            .as_str()
+            .ok_or("expected tag name to be a string")?[1..];
+        let latest_version_build = String::from_utf8(
+            fetch(
+                &HttpRequest::builder()
+                    .method(HttpMethod::Get)
+                    .url(format!(
+                        "https://download.eclipse.org/jdtls/milestones/{latest_version}/latest.txt"
+                    ))
+                    .build()?,
+            )?
+            .body,
+        )
+        .map_err(|err| err.to_string())?;
+        let latest_version_build = latest_version_build.trim_end();
+        // Exclude ".tar.gz"
+        let build_path = &latest_version_build[..latest_version_build.len() - 7];
+        let binary_path = format!("{build_path}/bin/{binary_name}");
 
-        // Prebuilt milestone versions available at:
-        // https://download.eclipse.org/jdtls/milestones/{version}
-        // Tarball filename is specified at
-        // https://download.eclipse.org/jdtls/milestones/{version}/latest.txt
+        // If latest version isn't installed,
+        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            // then download it...
 
-        let install_prefix = format!("jdt-language-server-{version}");
-        let binary_path = std::path::Path::new(&install_prefix)
-            .join("bin")
-            .join(binary_name)
-            .to_string_lossy()
-            .to_string();
-
-        // Validate binary
-        if !std::fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
             set_language_server_installation_status(
                 language_server_id,
                 &LanguageServerInstallationStatus::Downloading,
             );
+            download_file(&format!(
+                "https://www.eclipse.org/downloads/download.php?file=/jdtls/milestones/{latest_version}/{latest_version_build}",
+            ), build_path, DownloadedFileType::GzipTar)?;
+            make_file_executable(&binary_path)?;
 
-            // Download latest.txt to get the tarball filename
-            let latest_txt_path = format!("{install_prefix}-latest.txt");
-            let latest_txt_url =
-                format!("https://download.eclipse.org/jdtls/milestones/{version}/latest.txt");
-            download_file(
-                &latest_txt_url,
-                &latest_txt_path,
-                DownloadedFileType::Uncompressed,
-            )
-            .map_err(|e| format!("failed to download file: {e}"))
-            .inspect_err(|e| {
-                set_language_server_installation_status(
-                    language_server_id,
-                    &LanguageServerInstallationStatus::Failed(e.clone()),
-                );
-            })?;
-            let tarball_name = std::fs::read_to_string(&latest_txt_path)
-                .map_err(|e| format!("failed to read file {latest_txt_path} : {e}"))
-                .inspect_err(|e| {
-                    set_language_server_installation_status(
-                        language_server_id,
-                        &LanguageServerInstallationStatus::Failed(e.clone()),
-                    );
-                })?
-                .trim()
-                .to_string();
+            // ...and delete other versions
 
-            // Download tarball and extract
-            let tarball_url =
-                format!("https://download.eclipse.org/jdtls/milestones/{version}/{tarball_name}");
+            let entries = fs::read_dir(".").map_err(|err| err.to_string())?;
 
-            download_file(&tarball_url, &install_prefix, DownloadedFileType::GzipTar)
-                .map_err(|e| format!("failed to download file from {tarball_url} : {e}"))
-                .inspect_err(|e| {
-                    set_language_server_installation_status(
-                        language_server_id,
-                        &LanguageServerInstallationStatus::Failed(e.clone()),
-                    );
-                })?;
+            for entry in entries {
+                let entry = entry.map_err(|err| err.to_string())?;
 
-            make_file_executable(&binary_path)
-                .map_err(|e| format!("failed to make file {binary_path} executable: {e}"))
-                .inspect_err(|e| {
-                    set_language_server_installation_status(
-                        language_server_id,
-                        &LanguageServerInstallationStatus::Failed(e.clone()),
-                    );
-                })?;
+                if entry.file_name().to_str() != Some(build_path) {
+                    fs::remove_dir_all(entry.path()).ok();
+                }
+            }
         }
 
+        // else use it
+
         self.cached_binary_path = Some(binary_path.clone());
-        Ok(binary_path.clone())
+
+        Ok(binary_path)
     }
 
     fn lombok_jar_path(
@@ -256,9 +243,7 @@ impl Extension for Java {
         }
 
         Ok(zed::Command {
-            command: self
-                .language_server_binary_path(language_server_id, worktree)
-                .map_err(|e| format!("could not find language server binary: {e}"))?,
+            command: self.language_server_binary_path(language_server_id, worktree)?,
             args,
             env,
         })


### PR DESCRIPTION
This PR rewrites the code for downloading JDTLS, the language server. Now, it fetches GitHub tags to determine the latest version. Since the extension is now capable of determining the best version to download, the `jdtls_version` setting has been removed.