### PR TITLE
Correct `lombokSupport` in example initialization options in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ for example:
                 "/**/test/**"
               ]
             },
-            "lombokSupport": {
-              "enabled": false // Set this to true to enable lombok support
+            "jdt": {
+              "ls": {
+                "lombokSupport": {
+                  "enabled": true
+                }
+              }
             },
             "referencesCodeLens": {
               "enabled": false

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ for example:
             "jdt": {
               "ls": {
                 "lombokSupport": {
-                  "enabled": true
+                  "enabled": false // Set this to true to enable lombok support
                 }
               }
             },


### PR DESCRIPTION
Make config example more clear. 

the old config `initialization_options.settings.java.lombokSupport.enabled` not match current [code](https://github.com/zed-extensions/java/blob/283c160c0df0c3e8b872b12118ac8c517f705e4f/src/lib.rs#L310)