### PR TITLE
Use standard library path structure instead of plain string manipulation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeSet,
     fs::{self, create_dir},
+    path::Path,
 };
 
 use zed_extension_api::{
@@ -222,6 +223,7 @@ impl Java {
         let prefix = "lombok";
         let jar_name = format!("lombok-{latest_version}.jar");
         let jar_path = format!("{prefix}/{jar_name}");
+        let jar_path = Path::new(prefix).join(&jar_name).to_string_lossy().into_owned();
 
         // If latest version isn't installed,
         if !fs::metadata(&jar_path).is_ok_and(|stat| stat.is_file()) {


### PR DESCRIPTION
I encountered an error when activating Lombok on Windows:

```
Language server error: jdtls

oneshot canceled
-- stderr--
Error opening zip file or JAR manifest missing : /C:\Users\Myuser\AppData\Local\Zed\extensions\work\java/lombok/lombok-1.18.36.jar
```

I changed the line
```rust
let jar_path = format!("{prefix}/{jar_name}");
```
to
```rust
let jar_path = Path::new(prefix).join(&jar_name).to_string_lossy().into_owned();
```

I am not a Rust programmer, I don't know if it was correct!