### PR TITLE
Add toolchain toml.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This file makes rustup automaticaly configure the nightly toolchain which is used in this project.

Not sure if the project is meant to stay on nightly but if it does, this will simplify the development setup as f.e. zed will be automatically able to build the project.