### PR TITLE
Fix configuration settings (#43, #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This extension adds support for the Java language.
 
-## Initialization Options
+## Configuration Options
 
-If [Lombok] support is enabled via [JDTLS] initialization option
-(`initialization_options.settings.java.jdt.ls.lombokSupport.enabled`), this
+If [Lombok] support is enabled via [JDTLS] configuration option
+(`settings.java.jdt.ls.lombokSupport.enabled`), this
 extension will download and add [Lombok] as a javaagent to the JVM arguments for
 [JDTLS].
 
@@ -19,90 +19,89 @@ for example:
       "initialization_options": {
         "bundles": [],
         "workspaceFolders": ["file:///home/snjeza/Project"],
-        "settings": {
-          "java": {
-            "home": "/usr/local/jdk-9.0.1",
-            "errors": {
-              "incompleteClasspath": {
-                "severity": "warning"
-              }
+      },
+      "settings": {
+        "java": {
+          "home": "/usr/local/jdk-9.0.1",
+          "errors": {
+            "incompleteClasspath": {
+              "severity": "warning",
             },
-            "configuration": {
-              "updateBuildConfiguration": "interactive",
-              "maven": {
-                "userSettings": null
-              }
+          },
+          "configuration": {
+            "updateBuildConfiguration": "interactive",
+            "maven": {
+              "userSettings": null,
             },
-            "trace": {
-              "server": "verbose"
+          },
+          "trace": {
+            "server": "verbose",
+          },
+          "import": {
+            "gradle": {
+              "enabled": true,
             },
-            "import": {
-              "gradle": {
-                "enabled": true
+            "maven": {
+              "enabled": true,
+            },
+            "exclusions": [
+              "**/node_modules/**",
+              "**/.metadata/**",
+              "**/archetype-resources/**",
+              "**/META-INF/maven/**",
+              "/**/test/**",
+            ],
+          },
+          "jdt": {
+            "ls": {
+              "lombokSupport": {
+                "enabled": false, // Set this to true to enable lombok support
               },
-              "maven": {
-                "enabled": true
-              },
-              "exclusions": [
-                "**/node_modules/**",
-                "**/.metadata/**",
-                "**/archetype-resources/**",
-                "**/META-INF/maven/**",
-                "/**/test/**"
-              ]
             },
-            "jdt": {
-              "ls": {
-                "lombokSupport": {
-                  "enabled": false // Set this to true to enable lombok support
-                }
-              }
-            },
-            "referencesCodeLens": {
-              "enabled": false
-            },
-            "signatureHelp": {
-              "enabled": false
-            },
-            "implementationsCodeLens": {
-              "enabled": false
-            },
-            "format": {
-              "enabled": true
-            },
-            "saveActions": {
-              "organizeImports": false
-            },
-            "contentProvider": {
-              "preferred": null
-            },
-            "autobuild": {
-              "enabled": false
-            },
-            "completion": {
-              "favoriteStaticMembers": [
-                "org.junit.Assert.*",
-                "org.junit.Assume.*",
-                "org.junit.jupiter.api.Assertions.*",
-                "org.junit.jupiter.api.Assumptions.*",
-                "org.junit.jupiter.api.DynamicContainer.*",
-                "org.junit.jupiter.api.DynamicTest.*"
-              ],
-              "importOrder": ["java", "javax", "com", "org"]
-            }
-          }
-        }
-      }
-    }
-  }
+          },
+          "referencesCodeLens": {
+            "enabled": false,
+          },
+          "signatureHelp": {
+            "enabled": false,
+          },
+          "implementationsCodeLens": {
+            "enabled": false,
+          },
+          "format": {
+            "enabled": true,
+          },
+          "saveActions": {
+            "organizeImports": false,
+          },
+          "contentProvider": {
+            "preferred": null,
+          },
+          "autobuild": {
+            "enabled": false,
+          },
+          "completion": {
+            "favoriteStaticMembers": [
+              "org.junit.Assert.*",
+              "org.junit.Assume.*",
+              "org.junit.jupiter.api.Assertions.*",
+              "org.junit.jupiter.api.Assumptions.*",
+              "org.junit.jupiter.api.DynamicContainer.*",
+              "org.junit.jupiter.api.DynamicTest.*",
+            ],
+            "importOrder": ["java", "javax", "com", "org"],
+          },
+        },
+      },
+    },
+  },
 }
 ```
 
-*Example taken from JDTLS's [initialization options wiki page].*
+*Example taken from JDTLS's [configuration options wiki page].*
 
-You can see all the options JDTLS accepts [here][initialization options wiki
-page].
+You can see all the options JDTLS accepts [here][configuration options wiki page].
 
 [JDTLS]: https://github.com/eclipse-jdtls/eclipse.jdt.ls
-[initialization options wiki page]: https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request
+[configuration options wiki page]: https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request
 [Lombok]: https://projectlombok.org


### PR DESCRIPTION
- Closes: #42 
- Closes: #43

I just read nvim-jdtls [configuration example] and make hypotheses about jdtls.
And it turned out, the settings field in [InitializationOptions] is a field in [DidChangeConfigurationParams]. 
It is so..... stupid.

[configuration example]: https://github.com/mfussenegger/nvim-jdtls/blob/7223b812dde98f4260084fe9303c8301b9831a58/README.md?plain=1#L149-L152
[InitializationOptions]: https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request
[DidChangeConfigurationParams]: https://github.com/Microsoft/language-server-protocol/blob/main/versions/protocol-2-x.md#didchangeconfiguration-notification