### PR TITLE
Update README.md to more accurately reflect the configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,77 +19,77 @@ for example:
       "initialization_options": {
         "bundles": [],
         "workspaceFolders": ["file:///home/snjeza/Project"],
-      },
-      "settings": {
-        "java": {
-          "home": "/usr/local/jdk-9.0.1",
-          "errors": {
-            "incompleteClasspath": {
-              "severity": "warning",
-            },
-          },
-          "configuration": {
-            "updateBuildConfiguration": "interactive",
-            "maven": {
-              "userSettings": null,
-            },
-          },
-          "trace": {
-            "server": "verbose",
-          },
-          "import": {
-            "gradle": {
-              "enabled": true,
-            },
-            "maven": {
-              "enabled": true,
-            },
-            "exclusions": [
-              "**/node_modules/**",
-              "**/.metadata/**",
-              "**/archetype-resources/**",
-              "**/META-INF/maven/**",
-              "/**/test/**",
-            ],
-          },
-          "jdt": {
-            "ls": {
-              "lombokSupport": {
-                "enabled": false, // Set this to true to enable lombok support
+        "settings": {
+          "java": {
+            "home": "/usr/local/jdk-9.0.1",
+            "errors": {
+              "incompleteClasspath": {
+                "severity": "warning",
               },
             },
-          },
-          "referencesCodeLens": {
-            "enabled": false,
-          },
-          "signatureHelp": {
-            "enabled": false,
-          },
-          "implementationsCodeLens": {
-            "enabled": false,
-          },
-          "format": {
-            "enabled": true,
-          },
-          "saveActions": {
-            "organizeImports": false,
-          },
-          "contentProvider": {
-            "preferred": null,
-          },
-          "autobuild": {
-            "enabled": false,
-          },
-          "completion": {
-            "favoriteStaticMembers": [
-              "org.junit.Assert.*",
-              "org.junit.Assume.*",
-              "org.junit.jupiter.api.Assertions.*",
-              "org.junit.jupiter.api.Assumptions.*",
-              "org.junit.jupiter.api.DynamicContainer.*",
-              "org.junit.jupiter.api.DynamicTest.*",
-            ],
-            "importOrder": ["java", "javax", "com", "org"],
+            "configuration": {
+              "updateBuildConfiguration": "interactive",
+              "maven": {
+                "userSettings": null,
+              },
+            },
+            "trace": {
+              "server": "verbose",
+            },
+            "import": {
+              "gradle": {
+                "enabled": true,
+              },
+              "maven": {
+                "enabled": true,
+              },
+              "exclusions": [
+                "**/node_modules/**",
+                "**/.metadata/**",
+                "**/archetype-resources/**",
+                "**/META-INF/maven/**",
+                "/**/test/**",
+              ],
+            },
+            "jdt": {
+              "ls": {
+                "lombokSupport": {
+                  "enabled": false, // Set this to true to enable lombok support
+                },
+              },
+            },
+            "referencesCodeLens": {
+              "enabled": false,
+            },
+            "signatureHelp": {
+              "enabled": false,
+            },
+            "implementationsCodeLens": {
+              "enabled": false,
+            },
+            "format": {
+              "enabled": true,
+            },
+            "saveActions": {
+              "organizeImports": false,
+            },
+            "contentProvider": {
+              "preferred": null,
+            },
+            "autobuild": {
+              "enabled": false,
+            },
+            "completion": {
+              "favoriteStaticMembers": [
+                "org.junit.Assert.*",
+                "org.junit.Assume.*",
+                "org.junit.jupiter.api.Assertions.*",
+                "org.junit.jupiter.api.Assumptions.*",
+                "org.junit.jupiter.api.DynamicContainer.*",
+                "org.junit.jupiter.api.DynamicTest.*",
+              ],
+              "importOrder": ["java", "javax", "com", "org"],
+            },
           },
         },
       },
@@ -98,7 +98,7 @@ for example:
 }
 ```
 
-*Example taken from JDTLS's [configuration options wiki page].*
+_Example taken from JDTLS's [configuration options wiki page]._
 
 You can see all the options JDTLS accepts [here][configuration options wiki page].
 


### PR DESCRIPTION
Restructure the JSON configuration example to more accurately reflect the configuration example in the [Zed Java docs](https://zed.dev/docs/languages/java#zed-java-initialization-options) and the [initialize request example in eclipse.jdt.ls docs](https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request).