### PR TITLE
Add support for Java `.properties` files

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -14,6 +14,10 @@ repository = "https://github.com/zed-extensions/java"
 repository = "https://github.com/tree-sitter/tree-sitter-java"
 commit = "94703d5a6bed02b98e438d7cad1136c01a60ba2c"
 
+[grammars.properties]
+repository = "https://github.com/tree-sitter-grammars/tree-sitter-properties"
+commit = "579b62f5ad8d96c2bb331f07d1408c92767531d9"
+
 [language_servers.jdtls]
 name = "Eclipse JDT Language Server"
 language = "Java"

--- a/languages/properties/config.toml
+++ b/languages/properties/config.toml
@@ -1,0 +1,5 @@
+name = "Properties"
+grammar = "properties"
+path_suffixes = ["properties"]
+line_comments = ["# "]
+brackets = [{ start = "[", end = "]", close = true, newline = true }]

--- a/languages/properties/highlights.scm
+++ b/languages/properties/highlights.scm
@@ -1,0 +1,28 @@
+(comment) @comment
+
+(key) @property
+
+(value) @string
+
+(value (escape) @string.escape)
+
+((index) @number
+  (#match? @number "^[0-9]+$"))
+
+((substitution (key) @constant)
+  (#match? @constant "^[A-Z0-9_]+"))
+
+(substitution
+  (key) @function
+  "::" @punctuation.special
+  (secret) @embedded)
+
+(property [ "=" ":" ] @operator)
+
+[ "${" "}" ] @punctuation.special
+
+(substitution ":" @punctuation.special)
+
+[ "[" "]" ] @punctuation.bracket
+
+[ "." "\\" ] @punctuation.delimiter


### PR DESCRIPTION
Tree-sitter: https://github.com/tree-sitter-grammars/tree-sitter-properties

I don't use java, so don't know how useful this is, but it was easy enough to add support for. Thoughts @valentinegb?

- Closes: https://github.com/zed-industries/extensions/issues/2703 CC: @blacksoulgem95

<img width="1158" alt="Screenshot 2025-06-05 at 13 55 47" src="https://github.com/user-attachments/assets/5760e933-920b-4d8a-b3b6-8a6ca7c6360b" />

