### PR TITLE
Improve Java highlighting

### DIFF
--- a/languages/java/highlights.scm
+++ b/languages/java/highlights.scm
@@ -73,7 +73,7 @@
   name: (identifier) @type)
 
 (annotation_type_declaration
-  name: (identifier) @type)
+  name: (identifier) @attribute)
 
 (class_declaration
   name: (identifier) @type)
@@ -139,11 +139,11 @@
 
 ; Annotations
 (annotation
-  "@" @attribute
+  "@" @punctuation
   name: (identifier) @attribute)
 
 (marker_annotation
-  "@" @attribute
+  "@" @punctuation
   name: (identifier) @attribute)
 
 ; Literals
@@ -167,7 +167,7 @@
   (false)
 ] @boolean
 
-(null_literal) @type
+(null_literal) @constant.builtin
 
 ; Keywords
 [
@@ -212,7 +212,7 @@
   "yield"
 ] @keyword
 
-"new" @operator
+"new" @keyword.operator
 
 ; Conditionals
 [
@@ -289,7 +289,7 @@
   [
     "\\{"
     "}"
-  ] @string.special.symbol)
+  ] @punctuation) @embedded
 
 ; Exceptions
 [

--- a/languages/java/highlights.scm
+++ b/languages/java/highlights.scm
@@ -139,11 +139,11 @@
 
 ; Annotations
 (annotation
-  "@" @punctuation
+  "@" @punctuation.special
   name: (identifier) @attribute)
 
 (marker_annotation
-  "@" @punctuation
+  "@" @punctuation.special
   name: (identifier) @attribute)
 
 ; Literals
@@ -289,7 +289,7 @@
   [
     "\\{"
     "}"
-  ] @punctuation) @embedded
+  ] @punctuation.special) @embedded
 
 ; Exceptions
 [

--- a/languages/java/highlights.scm
+++ b/languages/java/highlights.scm
@@ -184,6 +184,7 @@
   "permits"
   "to"
   "with"
+  "new"
 ] @keyword
 
 [
@@ -211,8 +212,6 @@
   "return"
   "yield"
 ] @keyword
-
-"new" @keyword.operator
 
 ; Conditionals
 [


### PR DESCRIPTION
This PR makes Java highlighting more consistent with other languages.

Release Notes:

  - Improved Java highlighting

| Java 6.0.3 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/64897886-5711-43ea-b3f7-179d779d8ea6) | ![](https://github.com/user-attachments/assets/525b7d2f-df66-4a3e-ad61-8d52e4ed7e97) |

```java
@interface Annotation {
  String value() default "value";
}
interface Interface {
  public String message();
}
class Test implements Interface {
  @Annotation(value="test")
  public String message() {
    String string;
    String nothing = null;
    String formatted = STR."string: \{nothing}";
    return formatted;
  }
}
class Main {
  public static void main(String[] args) {
    Test test = new Test();
    System.out.println(test.message());
  }
}
```

- `Annotation`: `type` -> `attribute`, as in [Python](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/python/highlights.scm#L285), [Java](https://github.com/zed-extensions/java/blob/c4ac94b16b86815a1f2d6a6cd72bf851ca2bf07a/languages/java/highlights.scm#L143) itself
- `@`: `punctuation` as in [Python](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/python/highlights.scm#L40), [JavaScript](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/javascript/highlights.scm#L222), etc.
- `null`: `type` -> `constant.builtin`, as in [JavaScript](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/javascript/highlights.scm#L72), [Go](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/go/highlights.scm#L136), etc.
- `new`: `operator` -> `keyword.operator` as in [JavaScript](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/javascript/highlights.scm#L196), [C++](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/cpp/highlights.scm#L115), etc.
- `\{ }`: `string.special.symbol` -> `punctuation` `embedded`, as in [Python](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/python/highlights.scm#L149), [JavaScript](https://github.com/zed-industries/zed/blob/8332e60ca99187b1c08be50173357b2f1cc68dc4/crates/languages/src/javascript/highlights.scm#L214), etc.