### PR TITLE
Allow extension work even if maven is down

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -71,6 +71,10 @@ impl Debugger {
         }
     }
 
+    pub fn loaded(&self) -> bool {
+        self.plugin_path.is_some()
+    }
+
     pub fn get_or_download(
         &mut self,
         language_server_id: &LanguageServerId,

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -55,8 +55,7 @@ const SCOPES: [&str; 3] = [TEST_SCOPE, AUTO_SCOPE, RUNTIME_SCOPE];
 
 const PATH_TO_STR_ERROR: &str = "Failed to convert path to string";
 
-const MAVEN_SEARCH_URL: &str =
-    "https://search.maven.org/solrsearch/select?q=a:com.microsoft.java.debug.plugin";
+const MAVEN_METADATA_URL: &str = "https://repo1.maven.org/maven2/com/microsoft/java/com.microsoft.java.debug.plugin/maven-metadata.xml";
 
 pub struct Debugger {
     lsp: LspWrapper,
@@ -95,7 +94,7 @@ impl Debugger {
         let res = fetch(
             &HttpRequest::builder()
                 .method(HttpMethod::Get)
-                .url(MAVEN_SEARCH_URL)
+                .url(MAVEN_METADATA_URL)
                 .build()?,
         );
 
@@ -135,18 +134,20 @@ impl Debugger {
             }
         }
 
-        let maven_response_body = serde_json::from_slice::<Value>(&res?.body)
-            .map_err(|err| format!("failed to deserialize Maven response: {err}"))?;
+        let xml = String::from_utf8(res?.body).map_err(|err| {
+            format!("could not get string from maven metadata response body: {err}")
+        })?;
 
-        let latest_version = maven_response_body
-            .pointer("/response/docs/0/latestVersion")
-            .and_then(|v| v.as_str())
-            .ok_or("Malformed maven response")?;
+        let start_tag = "<latest>";
+        let end_tag = "</latest>";
 
-        let artifact = maven_response_body
-            .pointer("/response/docs/0/a")
-            .and_then(|v| v.as_str())
-            .ok_or("Malformed maven response")?;
+        let latest_version = xml
+            .split_once(start_tag)
+            .and_then(|(_, rest)| rest.split_once(end_tag))
+            .map(|(content, _)| content.trim())
+            .ok_or(format!("Failed to parse maven-metadata.xml response {xml}"))?;
+
+        let artifact = "com.microsoft.java.debug.plugin";
 
         let jar_name = format!("{artifact}-{latest_version}.jar");
         let jar_path = PathBuf::from(prefix).join(&jar_name);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ impl Extension for Java {
         worktree: &Worktree,
     ) -> zed_extension_api::Result<DebugAdapterBinary, String> {
         if !self.debugger().is_ok_and(|v| v.loaded()) {
-            return Err(format!("Debugger plugin is not loaded"));
+            return Err("Debugger plugin is not loaded".to_string());
         }
 
         if adapter_name != DEBUG_ADAPTER_NAME {
@@ -388,7 +388,7 @@ impl Extension for Java {
         config: zed::DebugConfig,
     ) -> zed::Result<zed::DebugScenario, String> {
         if !self.debugger().is_ok_and(|v| v.loaded()) {
-            return Err(format!("Debugger plugin is not loaded"));
+            return Err("Debugger plugin is not loaded".to_string());
         }
 
         match config.request {


### PR DESCRIPTION
Maven search has been down for 2 days straight :man_shrugging: 
I made the debug plugin optional in case the user hasn’t downloaded the plugin and Maven doesn’t respond.
Also replaced the logic for getting the LTS version from the Maven search API with parsing the maven-metadata.xml file.