### PR TITLE
Add overrides and update config accordingly

### DIFF
--- a/languages/java/config.toml
+++ b/languages/java/config.toml
@@ -7,13 +7,13 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = false },
-    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string_literal"] },
-    { start = "'", end = "'", close = true, newline = false, not_in = ["character_literal"] },
-    # TODO: Figure out how the Rust language support is able to handle block comments so well
-    { start = "/*", end = " */", close = true, newline = true, not_in = ["string_literal", "block_comment"] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
+    { start = "/*", end = " */", close = true, newline = true, not_in = ["string", "comment"] },
 ]
 collapsed_placeholder = " /* ... */ "
-documentation = { start = "/*", end = "*/", prefix = "* ", tab_size = 1 }
+block_comment = { start = "/*", prefix="", end = "*/", tab_size = 2 }
+documentation_comment = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
 prettier_parser_name = "java"
 prettier_plugins = ["prettier-plugin-java"]
 debuggers = ["Java"]

--- a/languages/java/overrides.scm
+++ b/languages/java/overrides.scm
@@ -1,0 +1,9 @@
+[
+  (block_comment)
+  (line_comment)
+] @comment.inclusive
+
+[
+  (character_literal)
+  (string_literal)
+] @string


### PR DESCRIPTION
Hey everyone!

I stumbled across the `TODO` whilst looking through the repo and since I fixed this issue earlier for the Kotlin extension, I thought I'd quickly do that for Java as well!

What was missing here for documentation comments to properly work was that we use the overrides from the `overrides.scm` for these wo work properly and you were missing that file. I believe we lack any documentation for that and I added that to my TODO-list. Hence, I added the `overrides.scm` here and updated the config accordingly.

Appreciate everything you do, with this change, documentation comments should now properly work (as well as some other goodies of disabled edit predictions in comments if you have that set in your settings). Let me know what you think, happy to adjust as needed.

Cheers!