### PR TITLE
Bump extension api, remove windows path workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-zed_extension_api = "0.6.0"
+zed_extension_api = "0.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,13 +430,6 @@ impl Extension for Java {
         let mut current_dir =
             current_dir().map_err(|err| format!("could not get current dir: {err}"))?;
 
-        if current_platform().0 == Os::Windows {
-            current_dir = current_dir
-                .strip_prefix("/")
-                .map_err(|err| err.to_string())?
-                .to_path_buf();
-        }
-
         let configuration =
             self.language_server_workspace_configuration(language_server_id, worktree)?;
         let java_home = configuration.as_ref().and_then(|configuration| {


### PR DESCRIPTION
⚠️ Don't merge until Zed 0.205.x is on stable ⚠️ 

See https://github.com/zed-industries/zed/pull/37811

This PR bumps the zed extension API to the latest version, which removes the need to work around a bug where `current_dir()` returned an invalid path on windows.