### PR TITLE
Fix EINVAL error when spawning the JDT LS process in Windows

### DIFF
--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -28,7 +28,7 @@ const args = process.argv.slice(3);
 const PROXY_ID = Buffer.from(process.cwd().replace(/\/+$/, "")).toString("hex");
 const PROXY_HTTP_PORT_FILE = join(workdir, "proxy", PROXY_ID);
 
-const lsp = spawn(bin, args);
+const lsp = spawn(bin, args, { shell: process.platform === 'win32' });
 const proxy = createLspProxy({ server: lsp, proxy: process });
 
 proxy.on("client", (data, passthrough) => {


### PR DESCRIPTION
Fixes #81

The Node `child_process.spawn` call to start JDTLS currently fails on Windows since .bat or .cmd files require a shell to run ([official docs](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows)). This PR amends that by passing `shell: true` on Windows systems.