### PR TITLE
Bump version to v6.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "zed_java"
-version = "6.4.1"
+version = "6.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_java"
-version = "6.4.1"
+version = "6.5.0"
 edition = "2024"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "java"
 name = "Java"
-version = "6.4.1"
+version = "6.5.0"
 schema_version = 1
 authors = [
     "Valentine Briese <valentinegb@icloud.com>",


### PR DESCRIPTION
This PR bump the version of the extension to 6.5.0.

Includes: 

- https://github.com/zed-extensions/java/pull/79
- https://github.com/zed-extensions/java/pull/84
- https://github.com/zed-extensions/java/pull/85
- https://github.com/zed-extensions/java/pull/87