### PR TITLE
make runnable tasks shell agnostic

### DIFF
--- a/languages/java/tasks.json
+++ b/languages/java/tasks.json
@@ -1,29 +1,53 @@
 [
   {
     "label": "Run $ZED_CUSTOM_java_class_name",
-    "command": "c=\"$ZED_CUSTOM_java_package_name.$ZED_CUSTOM_java_class_name\"; if [ -f pom.xml ]; then mvn clean compile exec:java -Dexec.mainClass=$c; elif [ -f gradlew ]; then ./gradlew run -PmainClass=$c; else >&2 echo 'No build system found'; exit 1; fi;",
+    "command": "c=\"$ZED_CUSTOM_java_package_name.$ZED_CUSTOM_java_class_name\"; if [ -f pom.xml ]; then ./mvnw clean compile exec:java -Dexec.mainClass=$c; elif [ -f gradlew ]; then ./gradlew run -PmainClass=$c; else >&2 echo 'No build system found'; exit 1; fi;",
     "use_new_terminal": false,
     "reveal": "always",
-    "tags": ["java-main"]
+    "tags": ["java-main"],
+    "shell": {
+      "with_arguments": {
+        "program": "/bin/sh",
+        "args": ["-c"]
+      }
+    }
   },
   {
     "label": "Test $ZED_CUSTOM_java_class_name.$ZED_CUSTOM_java_method_name",
-    "command": "c=\"$ZED_CUSTOM_java_package_name.$ZED_CUSTOM_java_class_name\"; m=\"$ZED_CUSTOM_java_method_name\"; if [ -f pom.xml ]; then mvn clean test -Dtest=\"$c#$m\"; elif [ -f gradlew ]; then ./gradlew test --tests $c.$m; else >&2 echo 'No build system found'; exit 1; fi;",
+    "command": "c=\"$ZED_CUSTOM_java_package_name.$ZED_CUSTOM_java_class_name\"; m=\"$ZED_CUSTOM_java_method_name\"; if [ -f pom.xml ]; then ./mvnw clean test -Dtest=\"$c#$m\"; elif [ -f gradlew ]; then ./gradlew test --tests $c.$m; else >&2 echo 'No build system found'; exit 1; fi;",
     "use_new_terminal": false,
     "reveal": "always",
-    "tags": ["java-test-method"]
+    "tags": ["java-test-method"],
+    "shell": {
+      "with_arguments": {
+        "program": "/bin/sh",
+        "args": ["-c"]
+      }
+    }
   },
   {
     "label": "Test class $ZED_CUSTOM_java_class_name",
-    "command": "c=\"$ZED_CUSTOM_java_package_name.$ZED_CUSTOM_java_class_name\"; if [ -f pom.xml ]; then mvn clean test -Dtest=\"$c\"; elif [ -f gradlew ]; then ./gradlew test --tests $c; else >&2 echo 'No build system found'; exit 1; fi;",
+    "command": "c=\"$ZED_CUSTOM_java_package_name.$ZED_CUSTOM_java_class_name\"; if [ -f pom.xml ]; then ./mvnw clean test -Dtest=\"$c\"; elif [ -f gradlew ]; then ./gradlew test --tests $c; else >&2 echo 'No build system found'; exit 1; fi;",
     "use_new_terminal": false,
     "reveal": "always",
-    "tags": ["java-test-class"]
+    "tags": ["java-test-class"],
+    "shell": {
+      "with_arguments": {
+        "program": "/bin/sh",
+        "args": ["-c"]
+      }
+    }
   },
   {
     "label": "Run tests",
-    "command": "if [ -f pom.xml ]; then mvn clean test; elif [ -f gradlew ]; then ./gradlew test; else >&2 echo 'No build system found'; exit 1; fi;",
+    "command": "if [ -f pom.xml ]; then ./mvnw clean test; elif [ -f gradlew ]; then ./gradlew test; else >&2 echo 'No build system found'; exit 1; fi;",
     "use_new_terminal": false,
-    "reveal": "always"
+    "reveal": "always",
+    "shell": {
+      "with_arguments": {
+        "program": "/bin/sh",
+        "args": ["-c"]
+      }
+    }
   }
 ]


### PR DESCRIPTION
force /bin/sh in case the users default shell is not a POSIX-shell (e.g. fish, nushell). This is a quick fix, it would be better to provide proper scripts somehow, and/or make them user-definable.

I also changed the scripts to use `./mvnw` instead of assuming a global `mvn` command in case of maven projects. 