### PR TITLE
Use our own fork of java-debug

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -55,7 +55,7 @@ const SCOPES: [&str; 3] = [TEST_SCOPE, AUTO_SCOPE, RUNTIME_SCOPE];
 
 const PATH_TO_STR_ERROR: &str = "Failed to convert path to string";
 
-const JAVA_DEBUG_PLUGIN_FORK_URL: &str = "https://github.com/playdohface/java-debug/releases/download/0.53.2/com.microsoft.java.debug.plugin-0.53.2.jar";
+const JAVA_DEBUG_PLUGIN_FORK_URL: &str = "https://github.com/zed-industries/java-debug/releases/download/0.53.2/com.microsoft.java.debug.plugin-0.53.2.jar";
 
 const MAVEN_METADATA_URL: &str = "https://repo1.maven.org/maven2/com/microsoft/java/com.microsoft.java.debug.plugin/maven-metadata.xml";
 


### PR DESCRIPTION
Closes #67

Zed and java-debug appear to disagree in their interpretations of the DAP-spec. Since we have no control over the release cycle of java-debug and indeed whether they accept the change to begin with, and the Zed team declines to adopt a more lenient stance in their interpretation of the spec, we must run our own fork of java-debug.

I've created a fork with the required fixes and a release for us to use here: https://github.com/playdohface/java-debug

This PR will make the extension download the forked release once if not installed yet, and then use it indefinitely. When the underlying issues are resolved either from Zeds side (https://github.com/zed-industries/zed/issues/37080) or java-debug merges our changes and makes a new release (https://github.com/microsoft/java-debug/pull/609) we can switch back our code to use the latest official release for java-debug.