### PR TITLE
Don't autoclose angle brackets

### DIFF
--- a/languages/java/config.toml
+++ b/languages/java/config.toml
@@ -7,7 +7,7 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = false },
-    { start = "<", end = ">", close = true, newline = false },
+    { start = "<", end = ">", close = false, newline = false },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
     { start = "/*", end = " */", close = true, newline = true, not_in = ["string", "comment"] },


### PR DESCRIPTION
Previously whenever a condition such as < was typed the corresponding closing bracket would also be autocompleted, this is extremely annoying and unhelpful for users. This disables autoclose. For class instantiation autocomplete already autocloses the closing bracket.