### PR TITLE
Add textobjects.scm for Java

### DIFF
--- a/languages/java/textobjects.scm
+++ b/languages/java/textobjects.scm
@@ -1,0 +1,65 @@
+; methods
+(method_declaration) @function.around
+(method_declaration
+  body: (block
+    "{" (_)* @function.inside "}"
+  ))
+
+; constructors
+(constructor_declaration) @function.around
+(constructor_declaration
+  body: (constructor_body
+    "{" (_)* @function.inside "}"
+  ))
+
+; lambdas
+(lambda_expression) @function.around
+(lambda_expression
+  body: (block
+    "{" (_)* @function.inside "}"
+  ))
+(lambda_expression
+  body: (_) @function.inside)
+
+
+; classes
+(class_declaration) @class.around
+(class_declaration
+  body: (class_body
+    "{" (_)* @class.inside "}"
+  ))
+
+; interfaces
+(interface_declaration) @class.around
+(interface_declaration
+  body: (interface_body
+    "{" (_)* @class.inside "}"
+  ))
+
+; enums
+(enum_declaration) @class.around
+(enum_declaration
+  body: (enum_body
+    "{"
+    _* @class.inside
+    "}"
+  ))
+
+; records
+(record_declaration) @class.around
+(record_declaration
+  body: (class_body
+    "{" (_)* @class.inside "}"
+  ))
+
+; annotations
+(annotation_type_declaration) @class.around
+(annotation_type_declaration
+  (annotation_type_body
+    "{" (_)* @class.inside "}"
+  ))
+
+
+; comments
+((line_comment)+) @comment.around
+(block_comment) @comment.around


### PR DESCRIPTION
This adds a `textobjects.scm` file to enable Tree-sitter-based text objects for Java.  Currently, Zed only supports this functionality in Vim mode. With this addition, you'll be able to treat several Java constructs as text objects and target them with any Vim operator like `d` (delete), `c` (change) or `y` (copy) or select them with `v`, as well as navigate code semantically. Here are the details:

- Use `ic` / `ac` to work **i**nside or **a**round a `class`, `interface`, `enum`, `record` and `annotation`
- Use `if` / `af` to work **i**nside or **a**round a `method`, `lambda` and `constructor`
- Use `igc` / `agc` to work **i**nside or **a**round a `single-line comment`, `multi-line comment`and `javadoc comment`
- Use `]m` / `[m` to go the next or previous `method` or `constructor`
- Use `]]` / `[[`to go the next or previous class-like construct (a `class`, `interface`, etc.).
- Use `]/` / `[/` to go to the next or previous `comment`.

If you are interested in knowing more about these features, you can find more information in the official Zed documentation for Tree-sitter and for Text Objects. The Default Vim Bindings file in Zed is also a good resource. There are good built-in text objects like `i` for indentation, `b` for blocks or `[x` / `]x` for selecting greater or smaller syntax nodes.