### PR TITLE
Recreate the debugger path before downloading the debugger.jar

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -104,6 +104,9 @@ impl Debugger {
             return Ok(path.clone());
         }
 
+        fs::remove_dir_all(prefix).map_err(|err| err.to_string())?;
+        fs::create_dir(prefix).map_err(|err| err.to_string())?;
+
         download_file(
             JAVA_DEBUG_PLUGIN_FORK_URL,
             &path_to_string(jar_path.clone())?,


### PR DESCRIPTION
Fixes #124 

When downloading the debugger-adapter-jar, we need to ensure the path exists. 