### PR TITLE
Expand usage of secure create_dir function

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -210,7 +210,7 @@ impl Debugger {
                 language_server_id,
                 &LanguageServerInstallationStatus::Downloading,
             );
-            fs::create_dir(prefix).map_err(|err| err.to_string())?;
+            create_path_if_not_exists(prefix)?;
 
             let url = format!(
                 "https://repo1.maven.org/maven2/com/microsoft/java/{artifact}/{latest_version}/{jar_name}"

--- a/src/jdtls.rs
+++ b/src/jdtls.rs
@@ -1,6 +1,6 @@
 use std::{
     env::current_dir,
-    fs::{create_dir, metadata, read_dir},
+    fs::{metadata, read_dir},
     path::{Path, PathBuf},
 };
 
@@ -18,8 +18,9 @@ use crate::{
     config::is_java_autodownload,
     jdk::try_to_fetch_and_install_latest_jdk,
     util::{
-        get_curr_dir, get_java_exec_name, get_java_executable, get_java_major_version,
-        get_latest_versions_from_tag, path_to_string, remove_all_files_except,
+        create_path_if_not_exists, get_curr_dir, get_java_exec_name, get_java_executable,
+        get_java_major_version, get_latest_versions_from_tag, path_to_string,
+        remove_all_files_except,
     },
 };
 
@@ -219,7 +220,7 @@ pub fn try_to_fetch_and_install_latest_lombok(
             language_server_id,
             &LanguageServerInstallationStatus::Downloading,
         );
-        create_dir(prefix).map_err(|err| err.to_string())?;
+        create_path_if_not_exists(prefix)?;
         download_file(
             &format!("https://projectlombok.org/downloads/{jar_name}"),
             path_to_string(jar_path.clone())?.as_str(),

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,6 +28,7 @@ const JAVA_EXEC_NOT_FOUND_ERROR: &str = "Could not find Java executable in JAVA_
 const TAG_RETRIEVAL_ERROR: &str = "Failed to fetch GitHub tags";
 const TAG_RESPONSE_ERROR: &str = "Failed to deserialize GitHub tags response";
 const TAG_UNEXPECTED_FORMAT_ERROR: &str = "Malformed GitHub tags response";
+const PATH_IS_NOT_DIR: &str = "File exists but is not a path";
 
 /// Create a Path if it does not exist
 ///
@@ -46,7 +47,7 @@ pub fn create_path_if_not_exists<P: AsRef<Path>>(path: P) -> zed::Result<()> {
             if metadata.is_dir() {
                 Ok(())
             } else {
-                Err(format!("File exists but is not a path: {:?}", path_ref))
+                Err(format!("{PATH_IS_NOT_DIR}: {:?}", path_ref))
             }
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {


### PR DESCRIPTION
Cover all insecure instances of create_dir which could have caused the extension to fail with the function `create_path_if_not_exists`