### PR TITLE
Improve the outline

### DIFF
--- a/languages/java/outline.scm
+++ b/languages/java/outline.scm
@@ -16,6 +16,18 @@
     body: (_) @item)
 
 (record_declaration
+    (modifiers
+        [
+            "private"
+            "public"
+            "protected"
+            "abstract"
+            "sealed"
+            "non-sealed"
+            "final"
+            "strictfp"
+            "static"
+        ]* @context)?
     "record" @context
     name: (_) @name
     body: (_) @item)
@@ -192,7 +204,7 @@
     (block) @item)
 
 (record_declaration
-    (formal_parameters
+    parameters: (formal_parameters
         (formal_parameter
             type: (_) @context
-            name: (_) @name @item)))
+            name: (_) @name) @item))


### PR DESCRIPTION
This PR adds several changes to improve the current state of the outline for multiple Java pieces of code. This will not only be reflected in the outline panel, but also in the buffer symbols, which in my case, is what I prefer to navigate across all the symbols in the current file. At the beginning, my motivation was to solve an issue related to how the methods were appearing in the sticky scroll, but this led me a rabbit hole where I discovered that a lot more was missing in the outline, namely the following:

Things that didn't appear in the outline before:

1. Constructors.
2. Any `class`, `interface`, `enum`, `record` and `annotation` (even if nested) that had no modifiers (access and non-access).
3. Fields and methods that had no modifiers (access and non-access).
4. Static blocks.
5. The types of the fields and the return type of methods.
6. Enum declaration.
7. Enum constants.
8. Annotation type declaration.
9. Annotation type elements.
10. The constant fields of an interface.
11. The parameters of a record constructor.

And lastly, these changes have as consequence also the fixing of an issue related to the sticky scroll. The purpose of the sticky scroll is to give you context about the class and the method you are currently in, which can be very useful in multiple scenarios. However, there was an issue that when a method or class had an annotation, that annotation would appear in the sticky scroll instead of the whole method declaration, defeating the purpose of the sticky scroll.

This feature was recently [introduced](https://github.com/zed-industries/zed/pull/42242#issue-3602402055) and can be enabled in `settings.json`:
```json
    "sticky_scroll": {
        "enabled": true
    }
 ```
**Limitations I found**: 
1. Currently, there's always a space after a parameter type in the outline. Even before these changes, when a method had parameters, even though the parameter types were not shown, there was a space left inside the parenthesis. After trying to solve this with no success, I'm very inclined to believe this is probably an issue on Zed's side. 
2. For records, the constructor parameters appear at the top level in the outline. To nest them under the record declaration, we need the entire `record_declaration` marked as `@item`, but marking the entire `record_declaration` as `@item` causes the sticky scroll to show the annotation (because it includes the entire text range starting with any annotation that is present).

**Before**:

https://github.com/user-attachments/assets/ba836bc7-3259-4e2b-b100-ce0e57c88b67




**Now**:

https://github.com/user-attachments/assets/12604ee1-7631-4b75-a95f-a30aff87add8



