### PR TITLE
fix(lsp): ensure child process terminates when parent exits

### DIFF
--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -60,6 +60,8 @@ process.stdin.on('end', () => {
   cleanup();
   process.exit(0);
 });
+// Ensure node is monitoring the pipe
+process.stdin.resume();
 
 // Fallback: monitor parent process for ungraceful shutdown
 setInterval(() => {


### PR DESCRIPTION
Address #41

Implemented a robust cleanup strategy for the spawned LSP process to prevent zombie processes:
- Added `detached: false` to the spawn configuration
- Implemented a `cleanup` function that attempts a graceful `SIGTERM`, followed by a forced `SIGKILL` after 1s if needed
- Added a listener on `stdin` end for graceful shutdown
- Added a watchdog interval to monitor the parent process (PPID); if the parent dies ungracefully, the LSP process will now self-terminate.