### PR TITLE
Remove `bug` label from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-grammar-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-grammar-bug.yml
@@ -1,6 +1,6 @@
 name: Grammar Bug
 description: A bug related to the Tree-Sitter grammar (e.g. syntax highlighting, auto-indents, outline, bracket-closing).
-labels: ["bug", "grammar"]
+labels: ["grammar"]
 type: "Bug"
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/2-language-server-bug.yml
+++ b/.github/ISSUE_TEMPLATE/2-language-server-bug.yml
@@ -1,6 +1,6 @@
 name: Language Server Bug
 description: A bug related to the language server (e.g. autocomplete, diagnostics, hover-docs, go to symbol, initialization options).
-labels: ["bug", "language-server"]
+labels: ["language-server"]
 type: "Bug"
 body:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/3-other-bug.yml
+++ b/.github/ISSUE_TEMPLATE/3-other-bug.yml
@@ -1,6 +1,6 @@
 name: Other Bug
 description: A bug related to something else!
-labels: ["bug"]
+labels: []
 type: "Bug"
 body:
   - type: textarea


### PR DESCRIPTION
I recently removed the `bug` label in favor of the `Bug` issue type, as it felt more reasonable to only have one of these. 

Hence, removing the `bug` labels from the issue templates here as a follow-up.