### PR TITLE
Prevent JDTLS from generating metadata files at project root

### DIFF
--- a/src/jdtls.rs
+++ b/src/jdtls.rs
@@ -77,6 +77,7 @@ pub fn build_jdtls_launch_args(
         ),
         "-Dosgi.sharedConfiguration.area.readOnly=true".to_string(),
         "-Dosgi.configuration.cascaded=true".to_string(),
+        "-Djava.import.generatesMetadataFilesAtProjectRoot=false".to_string(),
         "-Xms1G".to_string(),
         "--add-modules=ALL-SYSTEM".to_string(),
         "--add-opens".to_string(),


### PR DESCRIPTION
Address #178 

Add -Djava.import.generatesMetadataFilesAtProjectRoot=false system property to stop .project, .classpath, and .settings/ files from being created in the project directory.

This change follows the steps of other java extensions.

References:
1. JDTLS changes - https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/1900
1. Any way to get rid of .project .classpath .settings/ files? - https://github.com/redhat-developer/vscode-java/issues/618
1. Say goodbye to ".project" files in Language Support for Java 1.1.0 - https://devblogs.microsoft.com/java/say-goodbye-to-project-files-in-1-1-0/

