### PR TITLE
Add task to clear JDTLS cache in Java configuration

### DIFF
--- a/languages/java/tasks.json
+++ b/languages/java/tasks.json
@@ -51,8 +51,8 @@
     }
   },
   {
-    "label": "Clear JDTLS Cache",
-    "command": "if [ -n \"$XDG_CACHE_HOME\" ]; then rm -rf \"$XDG_CACHE_HOME/zed/jdtls\"*; elif [ \"$(uname)\" = \"Darwin\" ]; then rm -rf \"$HOME/Library/Caches/Zed/jdtls\"*; else rm -rf \"$HOME/.cache/zed/jdtls\"*; fi && echo 'JDTLS cache cleared. Restart the language server.'",
+    "label": "Clear JDTLS cache",
+    "command": "cache_dir=\"\"; if [ -n \"$XDG_CACHE_HOME\" ]; then cache_dir=\"$XDG_CACHE_HOME\"; elif [ \"$(uname)\" = \"Darwin\" ]; then cache_dir=\"$HOME/Library/Caches\"; else cache_dir=\"$HOME/.cache\"; fi; found=$(find \"$cache_dir\" -maxdepth 1 -type d -name 'jdtls-*' 2>/dev/null); if [ -n \"$found\" ]; then echo \"$found\" | xargs rm -rf && echo 'JDTLS cache cleared. Restart the language server'; else echo 'No JDTLS cache found'; fi",
     "use_new_terminal": false,
     "reveal": "always",
     "shell": {


### PR DESCRIPTION
Address #180 and partially #135

Provide an easy way to clear JDTLS's cache.
Currently supporting only Mac and Linux. Windows support will be added as soon as tasks have a more robust way to be OS-aware.