### PR TITLE
Accept both simple string and list of strings in args fields for debug config

### DIFF
--- a/debug_adapter_schemas/Java.json
+++ b/debug_adapter_schemas/Java.json
@@ -19,12 +19,32 @@
           "description": "The fully qualified name of the class containing the main method. If not specified, the debugger automatically resolves the possible main class from the current project."
         },
         "args": {
-          "type": "string",
-          "description": "The command line arguments passed to the program."
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "The command line arguments passed to the program. Can be a single string or an array of strings."
         },
         "vmArgs": {
-          "type": "string",
-          "description": "The extra options and system properties for the JVM (e.g., -Xms<size> -Xmx<size> -D<name>=<value>)."
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "The extra options and system properties for the JVM (e.g., -Xms<size> -Xmx<size> -D<name>=<value>). Can be a single string or an array of strings."
         },
         "encoding": {
           "type": "string",

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -13,8 +13,8 @@ use crate::{
     config::get_java_debug_jar,
     lsp::LspWrapper,
     util::{
-        create_path_if_not_exists, get_curr_dir, mark_checked_once, path_to_string,
-        should_use_local_or_download,
+        ArgsStringOrList, create_path_if_not_exists, get_curr_dir, mark_checked_once,
+        path_to_string, should_use_local_or_download,
     },
 };
 
@@ -27,9 +27,9 @@ struct JavaDebugLaunchConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     main_class: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    args: Option<String>,
+    args: Option<ArgsStringOrList>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    vm_args: Option<String>,
+    vm_args: Option<ArgsStringOrList>,
     #[serde(skip_serializing_if = "Option::is_none")]
     encoding: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use regex::Regex;
+use serde::{Deserialize, Serialize, Serializer};
 use std::{
     env::current_dir,
     fs,
@@ -399,5 +400,28 @@ pub fn should_use_local_or_download(
             Ok(None)
         }
         CheckUpdates::Always => Ok(None),
+    }
+}
+
+/// A type that can be deserialized from either a single string or a list of strings.
+///
+/// When serialized, it always produces a single string. If it was a list,
+/// the elements are joined with a space.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum ArgsStringOrList {
+    String(String),
+    List(Vec<String>),
+}
+
+impl Serialize for ArgsStringOrList {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            ArgsStringOrList::String(s) => serializer.serialize_str(s),
+            ArgsStringOrList::List(l) => serializer.serialize_str(&l.join(" ")),
+        }
     }
 }


### PR DESCRIPTION
Fixes #190 

Adds a new type for leniently deserialized argument-lists. Users can supply either a single string (with whitespace-separated args) or a list of strings (commonly this would be an element for each argument, but mix and match will work as well). Since we only pass these on we simply join them by space upon serializing them back to a string. 