### PR TITLE
feat(doxygen): add Javadoc/Doxygen syntax highlighting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -12,6 +12,10 @@ repository = "https://github.com/zed-extensions/java"
 repository = "https://github.com/tree-sitter/tree-sitter-java"
 commit = "94703d5a6bed02b98e438d7cad1136c01a60ba2c"
 
+[grammars.doxygen]
+repository = "https://github.com/da-r-k/tree-sitter-doxygen"
+commit = "4523f899192571744a9bb064c69594a157fa4a7d"
+
 [grammars.properties]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-properties"
 commit = "579b62f5ad8d96c2bb331f07d1408c92767531d9"

--- a/languages/doxygen/config.toml
+++ b/languages/doxygen/config.toml
@@ -1,0 +1,9 @@
+name = "Doxygen"
+grammar = "doxygen"
+autoclose_before = "]})>"
+brackets = [
+    { start = "{", end = "}", close = true, newline = false },
+    { start = "[", end = "]", close = true, newline = false },
+    { start = "(", end = ")", close = true, newline = false },
+]
+hidden = true

--- a/languages/doxygen/highlights.scm
+++ b/languages/doxygen/highlights.scm
@@ -1,38 +1,21 @@
 ((tag_name) @keyword
+  (#any-of? @keyword
+    "@param" "@return" "@returns" "@throws" "@exception"
+    "@see" "@since" "@version" "@author" "@deprecated"
+    "@serial" "@serialField" "@serialData"
+    "@link" "@linkplain" "@value" "@literal" "@code"
+    "@inheritDoc" "@docRoot" "@hidden" "@index"
+    "@provides" "@uses" "@implSpec" "@implNote" "@apiNote")
   (#set! "priority" 105))
-
-[
-  "@code"
-  "@endcode"
-] @keyword
-
-(identifier) @variable
 
 ((tag
   (tag_name) @_param
   (identifier) @variable.parameter)
-  (#any-of? @_param "@param" "\\param"))
+  (#any-of? @_param "@param"))
 
 (function (identifier) @function)
 
 (function_link) @function
-
-(emphasis) @markup.italic
-
-[
-  "\\a"
-  "\\c"
-] @tag
-
-(code_block_language) @label
-
-[
-  "in"
-  "out"
-  "inout"
-] @keyword.modifier
-
-"~" @operator
 
 [
   "<a"
@@ -41,13 +24,10 @@
 ] @tag
 
 [
-  "."
-  ","
-  "::"
-  (code_block_start)
-  (code_block_end)
-] @punctuation.delimiter
+  "@code"
+  "@endcode"
+] @keyword
+
+(code_block_language) @label
 
 ["(" ")" "{" "}" "[" "]"] @punctuation.bracket
-
-(code_block_content) @none

--- a/languages/doxygen/highlights.scm
+++ b/languages/doxygen/highlights.scm
@@ -1,0 +1,53 @@
+((tag_name) @keyword
+  (#set! "priority" 105))
+
+[
+  "@code"
+  "@endcode"
+] @keyword
+
+(identifier) @variable
+
+((tag
+  (tag_name) @_param
+  (identifier) @variable.parameter)
+  (#any-of? @_param "@param" "\\param"))
+
+(function (identifier) @function)
+
+(function_link) @function
+
+(emphasis) @markup.italic
+
+[
+  "\\a"
+  "\\c"
+] @tag
+
+(code_block_language) @label
+
+[
+  "in"
+  "out"
+  "inout"
+] @keyword.modifier
+
+"~" @operator
+
+[
+  "<a"
+  ">"
+  "</a>"
+] @tag
+
+[
+  "."
+  ","
+  "::"
+  (code_block_start)
+  (code_block_end)
+] @punctuation.delimiter
+
+["(" ")" "{" "}" "[" "]"] @punctuation.bracket
+
+(code_block_content) @none

--- a/languages/doxygen/injections.scm
+++ b/languages/doxygen/injections.scm
@@ -1,0 +1,7 @@
+((code_block
+  (code_block_language) @injection.language
+  (code_block_content) @injection.content))
+
+((code_block
+  (code_block_content) @injection.content)
+  (#set! injection.language "java"))

--- a/languages/java/injections.scm
+++ b/languages/java/injections.scm
@@ -5,7 +5,7 @@
   (#set! injection.language "comment"))
 
 ((block_comment) @injection.content
-  (#lua-match? @injection.content "/[*][!<*][^a-zA-Z]")
+  (#match? @injection.content "^/\\*\\*[^*]")
   (#set! injection.language "doxygen"))
 
 ((method_invocation


### PR DESCRIPTION
## Summary
Add syntax highlighting for Javadoc/Doxygen tags (`@param`, `@return`, `@throws`, etc.) inside `/** */` comments by integrating the `tree-sitter-doxygen` grammar.

## Changes
- Add `tree-sitter-doxygen` grammar to `extension.toml`
- Add `languages/doxygen/` with `config.toml` (hidden language) and `highlights.scm`
- Fix injection regex in `injections.scm` to properly match `/**` Javadoc comments

## Notes
- Uses a [WASM-compatible fork](https://github.com/da-r-k/tree-sitter-doxygen) of `tree-sitter-doxygen` because the upstream scanner uses libc functions (`fprintf`, `isalnum`, `iswspace`) unavailable in Zed's WASM sandbox
- Upstream PR to fix this: [tree-sitter-grammars/tree-sitter-doxygen#21](https://github.com/tree-sitter-grammars/tree-sitter-doxygen/pull/21)
- Once upstream merges, the grammar URL should be updated back to `tree-sitter-grammars/tree-sitter-doxygen`

## Testing
- Install as dev extension in Zed
- Open any Java file with Javadoc comments
- `@param`, `@return`, `@throws` etc. should be highlighted as keywords
- Parameter names after `@param` should be highlighted as variables

