### PR TITLE
Add configurable JVM memory settings for jdtls

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,24 @@ pub fn get_jdtls_launcher(configuration: &Option<Value>, worktree: &Worktree) ->
     None
 }
 
+/// Returns the max heap size for jdtls (e.g. "2G", "4096m").
+/// Maps to the `-Xmx` JVM argument.
+pub fn get_max_memory(configuration: &Option<Value>) -> Option<String> {
+    configuration
+        .as_ref()
+        .and_then(|c| c.pointer("/max_memory").and_then(|v| v.as_str()))
+        .map(|s| s.to_string())
+}
+
+/// Returns the initial heap size for jdtls (e.g. "512m", "1G").
+/// Maps to the `-Xms` JVM argument. Defaults to "1G".
+pub fn get_min_memory(configuration: &Option<Value>) -> Option<String> {
+    configuration
+        .as_ref()
+        .and_then(|c| c.pointer("/min_memory").and_then(|v| v.as_str()))
+        .map(|s| s.to_string())
+}
+
 pub fn get_lombok_jar(configuration: &Option<Value>, worktree: &Worktree) -> Option<String> {
     if let Some(configuration) = configuration
         && let Some(jar_path) = configuration

--- a/src/jdtls.rs
+++ b/src/jdtls.rs
@@ -105,9 +105,10 @@ pub fn build_jdtls_launch_args(
         if let Some(ref max_val) = max
             && let (Some(min_bytes), Some(max_bytes)) =
                 (parse_memory_value(&min), parse_memory_value(max_val))
-                && min_bytes > max_bytes {
-                    std::mem::swap(&mut min, max.as_mut().unwrap());
-                }
+            && min_bytes > max_bytes
+        {
+            std::mem::swap(&mut min, max.as_mut().unwrap());
+        }
         args.push(format!("-Xms{min}"));
         if let Some(max_val) = max {
             args.push(format!("-Xmx{max_val}"));

--- a/src/jdtls.rs
+++ b/src/jdtls.rs
@@ -99,15 +99,15 @@ pub fn build_jdtls_launch_args(
         "-Djava.import.generatesMetadataFilesAtProjectRoot=false".to_string(),
     ];
     {
-        let mut min = crate::config::get_min_memory(configuration).unwrap_or_else(|| "1G".to_string());
+        let mut min =
+            crate::config::get_min_memory(configuration).unwrap_or_else(|| "1G".to_string());
         let mut max = crate::config::get_max_memory(configuration);
-        if let Some(ref max_val) = max {
-            if let (Some(min_bytes), Some(max_bytes)) = (parse_memory_value(&min), parse_memory_value(max_val)) {
-                if min_bytes > max_bytes {
+        if let Some(ref max_val) = max
+            && let (Some(min_bytes), Some(max_bytes)) =
+                (parse_memory_value(&min), parse_memory_value(max_val))
+                && min_bytes > max_bytes {
                     std::mem::swap(&mut min, max.as_mut().unwrap());
                 }
-            }
-        }
         args.push(format!("-Xms{min}"));
         if let Some(max_val) = max {
             args.push(format!("-Xmx{max_val}"));

--- a/src/jdtls.rs
+++ b/src/jdtls.rs
@@ -34,6 +34,18 @@ const LOMBOK_REPO: &str = "projectlombok/lombok";
 const JAVA_VERSION_ERROR: &str = "JDTLS requires at least Java version 21 to run. You can either specify a different JDK to use by configuring lsp.jdtls.settings.java_home to point to a different JDK, or set lsp.jdtls.settings.jdk_auto_download to true to let the extension automatically download one for you.";
 const JDTLS_VERION_ERROR: &str = "No version to fallback to";
 
+/// Parse a JVM memory string (e.g. "2G", "512m", "1024k") into bytes.
+fn parse_memory_value(s: &str) -> Option<u64> {
+    let s = s.trim();
+    let (num, multiplier) = match s.as_bytes().last()? {
+        b'g' | b'G' => (&s[..s.len() - 1], 1024 * 1024 * 1024),
+        b'm' | b'M' => (&s[..s.len() - 1], 1024 * 1024),
+        b'k' | b'K' => (&s[..s.len() - 1], 1024),
+        _ => (s, 1),
+    };
+    num.parse::<u64>().ok().map(|n| n * multiplier)
+}
+
 pub fn build_jdtls_launch_args(
     jdtls_path: &PathBuf,
     configuration: &Option<Value>,
@@ -85,13 +97,29 @@ pub fn build_jdtls_launch_args(
         "-Dosgi.sharedConfiguration.area.readOnly=true".to_string(),
         "-Dosgi.configuration.cascaded=true".to_string(),
         "-Djava.import.generatesMetadataFilesAtProjectRoot=false".to_string(),
-        "-Xms1G".to_string(),
+    ];
+    {
+        let mut min = crate::config::get_min_memory(configuration).unwrap_or_else(|| "1G".to_string());
+        let mut max = crate::config::get_max_memory(configuration);
+        if let Some(ref max_val) = max {
+            if let (Some(min_bytes), Some(max_bytes)) = (parse_memory_value(&min), parse_memory_value(max_val)) {
+                if min_bytes > max_bytes {
+                    std::mem::swap(&mut min, max.as_mut().unwrap());
+                }
+            }
+        }
+        args.push(format!("-Xms{min}"));
+        if let Some(max_val) = max {
+            args.push(format!("-Xmx{max_val}"));
+        }
+    }
+    args.extend(vec![
         "--add-modules=ALL-SYSTEM".to_string(),
         "--add-opens".to_string(),
         "java.base/java.util=ALL-UNNAMED".to_string(),
         "--add-opens".to_string(),
         "java.base/java.lang=ALL-UNNAMED".to_string(),
-    ];
+    ]);
     args.extend(jvm_args);
     args.extend(vec![
         "-jar".to_string(),


### PR DESCRIPTION
Add `get_max_memory` and `get_min_memory` config functions to read heap size settings. Implement `parse_memory_value` to convert JVM memory strings (e.g. "2G", "512m") to bytes. Update launch args to use configured values with validation to ensure min doesn't exceed max, defaulting to "1G" for initial heap.

Address #234 