### PR TITLE
Support Java files without package declarations

### DIFF
--- a/languages/java/runnables.scm
+++ b/languages/java/runnables.scm
@@ -1,6 +1,9 @@
 ; Run the main function
 ((package_declaration
-  (scoped_identifier) @java_package_name)?
+  [
+    (scoped_identifier)
+    (identifier)
+  ] @java_package_name)?
   (class_declaration
     (modifiers) @class-modifier
     (#match? @class-modifier "public")
@@ -16,7 +19,10 @@
 
 ; Run the main class
 ((package_declaration
-  (scoped_identifier) @java_package_name)?
+  [
+    (scoped_identifier)
+    (identifier)
+  ] @java_package_name)?
   (class_declaration
     (modifiers) @class-modifier
     (#match? @class-modifier "public")
@@ -31,8 +37,12 @@
   (#set! tag java-main))
 
 ; Run test function (marker annotation, e.g. @Test)
-((package_declaration
-  (scoped_identifier) @java_package_name)
+(program
+  (package_declaration
+    [
+      (scoped_identifier)
+      (identifier)
+    ] @java_package_name)?
   (class_declaration
     name: (identifier) @java_class_name
     body: (class_body
@@ -49,8 +59,12 @@
   (#set! tag java-test-method))
 
 ; Run nested test function
-((package_declaration
-  (scoped_identifier) @java_package_name)
+(program
+  (package_declaration
+    [
+      (scoped_identifier)
+      (identifier)
+    ] @java_package_name)?
   (class_declaration
     name: (identifier) @java_outer_class_name
     body: (class_body
@@ -74,8 +88,12 @@
   (#set! tag java-test-method-nested))
 
 ; Run test class
-((package_declaration
-  (scoped_identifier) @java_package_name)
+(program
+  (package_declaration
+    [
+      (scoped_identifier)
+      (identifier)
+    ] @java_package_name)?
   (class_declaration
     name: (identifier) @java_class_name @run
     body: (class_body
@@ -91,8 +109,12 @@
   (#set! tag java-test-class))
 
 ; Run nested test class
-((package_declaration
-  (scoped_identifier) @java_package_name)
+(program
+  (package_declaration
+    [
+      (scoped_identifier)
+      (identifier)
+    ] @java_package_name)?
   (class_declaration
     name: (identifier) @java_outer_class_name
     body: (class_body

--- a/languages/java/tasks.json
+++ b/languages/java/tasks.json
@@ -14,7 +14,7 @@
   },
   {
     "label": "$ZED_CUSTOM_java_class_name.${ZED_CUSTOM_java_outer_class_name:}.$ZED_CUSTOM_java_method_name",
-    "command": "package=\"$ZED_CUSTOM_java_package_name\"; outer=\"${ZED_CUSTOM_java_outer_class_name:}\"; inner=\"$ZED_CUSTOM_java_class_name\"; method=\"$ZED_CUSTOM_java_method_name\"; sep=\"$\"; if [ -n \"$outer\" ]; then c=\"$outer$sep$inner\"; else c=\"$inner\"; fi; if [ -f pom.xml ]; then [ -f ./mvnw ] && CMD=\"./mvnw\" || CMD=\"mvn\"; $CMD clean test -Dtest=\"$package.$c#$method\"; elif [ -f build.gradle ] || [ -f build.gradle.kts ]; then [ -f ./gradlew ] && CMD=\"./gradlew\" || CMD=\"gradle\"; $CMD test --tests \"$package.$c.$method\"; else >&2 echo 'No build tool found'; exit 1; fi;",
+    "command": "package=\"${ZED_CUSTOM_java_package_name:}\"; outer=\"${ZED_CUSTOM_java_outer_class_name:}\"; inner=\"$ZED_CUSTOM_java_class_name\"; method=\"$ZED_CUSTOM_java_method_name\"; sep=\"$\"; if [ -n \"$outer\" ]; then c=\"$outer$sep$inner\"; else c=\"$inner\"; fi; if [ -n \"$package\" ]; then fqc=\"$package.$c\"; else fqc=\"$c\"; fi; if [ -f pom.xml ]; then [ -f ./mvnw ] && CMD=\"./mvnw\" || CMD=\"mvn\"; $CMD clean test -Dtest=\"$fqc#$method\"; elif [ -f build.gradle ] || [ -f build.gradle.kts ]; then [ -f ./gradlew ] && CMD=\"./gradlew\" || CMD=\"gradle\"; $CMD test --tests \"$fqc.$method\"; else >&2 echo 'No build tool found'; exit 1; fi;",
     "use_new_terminal": false,
     "reveal": "always",
     "tags": ["java-test-method", "java-test-method-nested"],
@@ -27,7 +27,7 @@
   },
   {
     "label": "Test class $ZED_CUSTOM_java_class_name",
-    "command": "package=\"$ZED_CUSTOM_java_package_name\"; outer=\"${ZED_CUSTOM_java_outer_class_name:}\"; inner=\"$ZED_CUSTOM_java_class_name\"; sep=\"$\"; if [ -n \"$outer\" ]; then c=\"$outer$sep$inner\"; else c=\"$inner\"; fi; if [ -f pom.xml ]; then [ -f ./mvnw ] && CMD=\"./mvnw\" || CMD=\"mvn\"; $CMD clean test -Dtest=\"$package.$c\"; elif [ -f build.gradle ] || [ -f build.gradle.kts ]; then [ -f ./gradlew ] && CMD=\"./gradlew\" || CMD=\"gradle\"; $CMD test --tests \"$package.$c\"; else >&2 echo 'No build tool found'; exit 1; fi;",
+    "command": "package=\"${ZED_CUSTOM_java_package_name:}\"; outer=\"${ZED_CUSTOM_java_outer_class_name:}\"; inner=\"$ZED_CUSTOM_java_class_name\"; sep=\"$\"; if [ -n \"$outer\" ]; then c=\"$outer$sep$inner\"; else c=\"$inner\"; fi; if [ -n \"$package\" ]; then fqc=\"$package.$c\"; else fqc=\"$c\"; fi; if [ -f pom.xml ]; then [ -f ./mvnw ] && CMD=\"./mvnw\" || CMD=\"mvn\"; $CMD clean test -Dtest=\"$fqc\"; elif [ -f build.gradle ] || [ -f build.gradle.kts ]; then [ -f ./gradlew ] && CMD=\"./gradlew\" || CMD=\"gradle\"; $CMD test --tests \"$fqc\"; else >&2 echo 'No build tool found'; exit 1; fi;",
     "use_new_terminal": false,
     "reveal": "always",
     "tags": ["java-test-class", "java-test-class-nested"],


### PR DESCRIPTION
Allow matching both scoped identifiers and simple identifiers for package names, and make package declarations optional. Update task commands to handle cases where package name is not defined.

Address #241