### PR TITLE
refactor: replace potential panics with safe error handling

### DIFF
--- a/src/java.rs
+++ b/src/java.rs
@@ -386,7 +386,9 @@ impl Extension for Java {
             .unwrap_or_else(|| json!({}));
 
         // Inject workspaceFolders default if not already set by the user
-        let options_obj = options.as_object_mut().unwrap();
+        let options_obj = options
+            .as_object_mut()
+            .ok_or_else(|| "initialization_options is not a JSON object".to_string())?;
         if !options_obj.contains_key("workspaceFolders") {
             let uri = util::path_to_file_uri(&worktree.root_path());
             options_obj.insert("workspaceFolders".to_string(), json!([uri]));
@@ -396,7 +398,9 @@ impl Extension for Java {
         let caps = options_obj
             .entry("extendedClientCapabilities")
             .or_insert_with(|| json!({}));
-        let caps_obj = caps.as_object_mut().unwrap();
+        let caps_obj = caps
+            .as_object_mut()
+            .ok_or_else(|| "extendedClientCapabilities is not a JSON object".to_string())?;
         caps_obj
             .entry("classFileContentsSupport")
             .or_insert(json!(true));
@@ -575,7 +579,7 @@ impl Extension for Java {
                     SymbolKind::Class => "class ",
                     SymbolKind::Interface => "interface ",
                     SymbolKind::Enum => "enum ",
-                    _ => unreachable!(),
+                    _ => return None,
                 };
                 let code = format!("{keyword}{name} {{}}");
 

--- a/src/jdtls.rs
+++ b/src/jdtls.rs
@@ -106,8 +106,9 @@ pub fn build_jdtls_launch_args(
             && let (Some(min_bytes), Some(max_bytes)) =
                 (parse_memory_value(&min), parse_memory_value(max_val))
             && min_bytes > max_bytes
+            && let Some(max) = max.as_mut()
         {
-            std::mem::swap(&mut min, max.as_mut().unwrap());
+            std::mem::swap(&mut min, max);
         }
         args.push(format!("-Xms{min}"));
         if let Some(max_val) = max {
@@ -214,10 +215,11 @@ pub fn try_to_fetch_and_install_latest_jdtls(
         .map_or_else(
             |_| {
                 second_last
-                    .as_ref()
                     .ok_or(JDTLS_VERION_ERROR.to_string())
-                    .and_then(|fallback| download_jdtls_milestone(fallback))
-                    .map(|milestone| (second_last.unwrap(), milestone.trim_end().to_string()))
+                    .and_then(|fallback| {
+                        download_jdtls_milestone(&fallback)
+                            .map(|milestone| (fallback, milestone.trim_end().to_string()))
+                    })
             },
             |milestone| Ok((last, milestone.trim_end().to_string())),
         )?;
@@ -396,11 +398,12 @@ fn get_jdtls_data_path(worktree: &Worktree) -> zed::Result<PathBuf> {
             .find(|(k, _)| k == "APPDATA")
             .map(|(_, v)| PathBuf::from(v)),
     }
+    .map(Ok)
     .unwrap_or_else(|| {
         current_dir()
-            .expect("should be able to get extension workdir")
-            .join("caches")
-    });
+            .map_err(|err| format!("Failed to get current directory: {err}"))
+            .map(|path| path.join("caches"))
+    })?;
 
     // caches are unique per worktree-root-path
     let cache_key = worktree.root_path();

--- a/src/util.rs
+++ b/src/util.rs
@@ -275,12 +275,10 @@ pub fn get_latest_versions_from_tag(repo: &str) -> zed::Result<(String, Option<S
     let latest_version = get_tag_at(&tags_response_body, 0);
     let second_version = get_tag_at(&tags_response_body, 1);
 
-    if latest_version.is_none() {
-        return Err(TAG_UNEXPECTED_FORMAT_ERROR.to_string());
-    }
+    let latest_version = latest_version.ok_or_else(|| TAG_UNEXPECTED_FORMAT_ERROR.to_string())?;
 
     Ok((
-        latest_version.unwrap().to_string(),
+        latest_version.to_string(),
         second_version.map(|second| second.to_string()),
     ))
 }


### PR DESCRIPTION
- Replace panicking calls in `java.rs`, `jdtls.rs`, and `util.rs` with safe `Result` propagation.
- Handle malformed LSP settings and unexpected symbol kinds gracefully.
- Avoid hard crashes in favor of logged errors.