### PR TITLE
docs(initialization): update sourcePaths configuration path

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,12 +376,13 @@ MyProject/
 "lsp": {
   "jdtls": {
     "initialization_options": {
-      "project": {
-        "sourcePaths": [
-          ".",
-          "src"
-        ]
-      },
+      "settings": {
+        "java": {
+          "project": {
+            "sourcePaths": [".", "src"],
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Changes
* Update the suggested `settings.json` initialization options configuration for fixing package declarations not matching source file paths to use the correct structure
  * Found in a separate issue's thread: https://github.com/zed-industries/zed/discussions/34422#discussioncomment-14014666
  * From JDTLS's [initialization request structure](https://github.com/eclipse-jdtls/eclipse.jdt.ls/wiki/Running-the-JAVA-LS-server-from-the-command-line#initialize-request): `InitializationOptions` -> `settings?: JavaConfigurationSettings` -> `java?: JavaConfiguration` -> `project?: ProjectOptions` -> `sourcePaths?: string[]`

## Why
The original configuration didn't work for me in a new project that I am not using Maven or Gradle in so this may help others facing the same issue.
