### PR TITLE
Prefer IPv4 in JVM launch args for JDTLS

### DIFF
--- a/src/jdtls.rs
+++ b/src/jdtls.rs
@@ -296,6 +296,7 @@ pub fn build_jdtls_launch_args(
         "-Dosgi.sharedConfiguration.area.readOnly=true".to_string(),
         "-Dosgi.configuration.cascaded=true".to_string(),
         "-Djava.import.generatesMetadataFilesAtProjectRoot=false".to_string(),
+        "-Djava.net.preferIPv4Stack=true".to_string(),
     ];
     {
         let mut min =


### PR DESCRIPTION
Relates to #260 

I don't have Windows to test on, so I can not reproduce the original issue but this effectively makes the fix from the issue the default