### PR TITLE
fix(properties): scope completion query characters to property nodes

### DIFF
--- a/languages/properties/config.toml
+++ b/languages/properties/config.toml
@@ -3,3 +3,6 @@ grammar = "properties"
 path_suffixes = ["properties"]
 line_comments = ["# "]
 brackets = [{ start = "[", end = "]", close = true, newline = true }]
+
+[overrides.property]
+completion_query_characters = [".", "-"]

--- a/languages/properties/overrides.scm
+++ b/languages/properties/overrides.scm
@@ -1,0 +1,4 @@
+; Property keys are typed left-to-right, so the cursor sits at the end of the
+; node; a non-inclusive capture would exclude that offset (see Zed's
+; SyntaxLayer::override_id) and the override would never apply while typing.
+(property) @property.inclusive


### PR DESCRIPTION
Fixes #287.

### Problem

Typing a dotted key such as `server.p` in `application.properties` pushes `server.port` out of the completion menu entirely, while unrelated deeper keys (`server.ssl.key-password`, `server.tomcat.max-part-header-size`) rank at the top.

The cause is on the query side, not the ranking side. Zed builds the fuzzy query from the surrounding word at the cursor (`Editor::completion_query` → `surrounding_word(offset, Some(CharScopeContext::Completion))`), and `.` is not a word character for the Properties language. So at `server.p` the query collapses to `p`, every candidate containing a `p` matches, and the exact prefix match loses.

This is independent of what the server advertises. The completions here come from the [Spring Boot Language Server](https://github.com/spring-projects/sts4) — the same server that backs the VS Code Spring Boot Tools extension — which I reach in Zed through [zed-spring-tools](https://github.com/luceat-lux-vestra/zed-spring-tools). It returns `server.port` as its first item with `sortText: "00000"`; the item is present in the LSP response and simply never surfaces in the menu.

### Fix

Declare `completion_query_characters` for Properties so the query is the whole dotted key. As @tartarughina suggested, the override is scoped to `property` rather than `string`. The setting only takes effect through an override scope, so this also adds the matching `overrides.scm` — without it the `config.toml` block is inert.

The capture must be `.inclusive`. A key is typed left-to-right, so the cursor sits at the **end offset** of the `property` node, and `SyntaxLayer::override_id` skips non-inclusive captures when `offset >= range.end`.

### Verification

Driven in Zed `1.11.3+stable.326` against a Spring Boot 3 project with the official Java extension and jdtls running, so the completions are classpath-backed.

Cursor at the end of `server.p`:

| `overrides.scm` | extracted query | result |
|---|---|---|
| *(file absent)* | `p` | `server.port` absent; `server.ssl.key-password` first |
| `(property) @property` | `p` | unchanged — override never applies at the node's end offset |
| `(property) @property.inclusive` | `server.p` | **`server.port` first**, `server.` highlighted on every item |

**Before** — at `server.p`, `server.port` is absent from the menu and `server.ssl.key-password` ranks first:

<img width="820" alt="Before" src="https://github.com/user-attachments/assets/cff2ea57-fd7c-46ee-9c14-5df6fcf52473" />

**After** — same cursor with `(property) @property.inclusive`, `server.port` is the first item:

<img width="820" alt="After" src="https://github.com/user-attachments/assets/e2590fd4-17e0-415a-80d8-5aecac8d410a" />

### Known residual

Two things are out of reach from the extension:

1. If the property is on the final line **without a trailing newline**, the override still does not apply. Files ending in a newline (the default on save) are unaffected.
2. Below the top hit the order is still Zed's fuzzy score rather than the server's `sortText` — `sort_score` is compared before `sort_text` in `sort_string_matches`, and deprecated items are not deprioritised, so a deprecated key can rank third. I've filed that separately as zed-industries/zed#61349.
